### PR TITLE
Add database views for popular tags.

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,45 +2,14 @@ class TagsController < ApplicationController
   include TalkResource
   
   def popular
-    params.permit!
-    raise ActionController::ParameterMissing.new(:section) unless params[:section]
-    limit = clamp params.fetch(:limit, 10).to_i, (1..20)
-    scoped = Tag.in_section params[:section]
-    scoped = scoped.of_type(params[:type]) if params[:type]
-    scoped = scoped.popular limit: limit
-    render json: {
-      tags: tags_from(scoped.keys),
-      meta: popular_meta_for(scoped.count, limit)
-    }
+    render json: popular_serializer.resource(params, nil, current_user: current_user)
   end
   
-  protected
-  
-  def popular_meta_for(count, limit)
-    {
-      tags: {
-        page: 1,
-        page_size: limit,
-        count: count,
-        include: [],
-        page_count: 1,
-        previous_page: nil,
-        next_page: nil,
-        first_href: '/tags/popular',
-        previous_href: nil,
-        next_href: nil,
-        last_href: '/tags/popular'
-      }
-    }
-  end
-  
-  def tags_from(names)
-    names.collect{ |name| Tag.new(name: name, section: params[:section], taggable_type: params[:type]) }
-  end
-  
-  def clamp(value, range)
-    value = [value, range.min].max
-    value = [value, range.max].min
-    value
+  def popular_serializer
+    if params[:taggable_id] || params[:taggable_type]
+      PopularFocusTagSerializer
+    else
+      PopularTagSerializer
+    end
   end
 end

--- a/app/models/popular_focus_tag.rb
+++ b/app/models/popular_focus_tag.rb
@@ -1,0 +1,3 @@
+class PopularFocusTag < ActiveRecord::Base
+  self.primary_key = :id
+end

--- a/app/models/popular_tag.rb
+++ b/app/models/popular_tag.rb
@@ -1,0 +1,3 @@
+class PopularTag < ActiveRecord::Base
+  self.primary_key = :id
+end

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -3,6 +3,10 @@ class TagPolicy < ApplicationPolicy
     true
   end
   
+  def popular?
+    true
+  end
+  
   def show?
     comment_policy.show?
   end

--- a/app/serializers/popular_focus_tag_serializer.rb
+++ b/app/serializers/popular_focus_tag_serializer.rb
@@ -1,0 +1,13 @@
+class PopularFocusTagSerializer
+  include TalkSerializer
+  all_attributes
+  can_filter_by :taggable_id, :taggable_type
+  
+  def self.key
+    'popular'
+  end
+  
+  def self.href_prefix
+    '/tags'
+  end
+end

--- a/app/serializers/popular_tag_serializer.rb
+++ b/app/serializers/popular_tag_serializer.rb
@@ -1,0 +1,12 @@
+class PopularTagSerializer
+  include TalkSerializer
+  all_attributes
+  
+  def self.key
+    'popular'
+  end
+  
+  def self.href_prefix
+    '/tags'
+  end
+end

--- a/app/serializers/tag_serializer.rb
+++ b/app/serializers/tag_serializer.rb
@@ -2,6 +2,7 @@ class TagSerializer
   include TalkSerializer
   include EmbeddedAttributes
   all_attributes
+  can_filter_by :taggable_id, :taggable_type
   embed_attributes_from :project
   self.eager_loads = [:project]
 end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -27,35 +27,13 @@ RSpec.describe TagsController, type: :controller do
     RSpec.shared_context 'TagsController#popular' do
       let(:params){ { } }
       subject{ response }
-      let(:tags){ response.json['tags'] }
+      let(:tags){ response.json['popular'] }
       let(:tag_names){ tags.collect{ |h| h['name'] } }
       before(:each){ get :popular, params }
     end
     
-    RSpec.shared_examples_for 'TagsController#popular_meta_for' do |expected_count: nil, expected_limit: nil|
-      subject{ OpenStruct.new response.json['meta']['tags'] }
-      its(:page){ is_expected.to eql 1 }
-      its(:page_size){ is_expected.to eql expected_limit }
-      its(:count){ is_expected.to eql expected_count }
-      its(:include){ is_expected.to eql [] }
-      its(:page_count){ is_expected.to eql 1 }
-      its(:previous_page){ is_expected.to be_nil }
-      its(:next_page){ is_expected.to be_nil }
-      its(:first_href){ is_expected.to eql '/tags/popular' }
-      its(:previous_href){ is_expected.to be_nil }
-      its(:next_href){ is_expected.to be_nil }
-      its(:last_href){ is_expected.to eql '/tags/popular' }
-    end
-    
-    context 'without a section' do
-      include_context 'TagsController#popular'
-      it{ is_expected.to be_unprocessable }
-      its(:json){ is_expected.to eql 'error' => 'param is missing or the value is empty: section' }
-    end
-    
     context 'with an empty section' do
       include_context 'TagsController#popular'
-      it_behaves_like 'TagsController#popular_meta_for', expected_count: 0, expected_limit: 10
       let(:params){ { section: 'project-1' } }
       it{ is_expected.to be_successful }
       
@@ -67,7 +45,6 @@ RSpec.describe TagsController, type: :controller do
     
     context 'with a section' do
       include_context 'TagsController#popular'
-      it_behaves_like 'TagsController#popular_meta_for', expected_count: 4, expected_limit: 10
       let(:params){ { section: section } }
       it{ is_expected.to be_successful }
       
@@ -79,25 +56,12 @@ RSpec.describe TagsController, type: :controller do
     
     context 'with a type' do
       include_context 'TagsController#popular'
-      it_behaves_like 'TagsController#popular_meta_for', expected_count: 2, expected_limit: 10
-      let(:params){ { section: section, type: 'subject' } }
+      let(:params){ { section: section, taggable_type: 'Subject' } }
       it{ is_expected.to be_successful }
       
       describe 'response' do
         subject{ tag_names }
         it{ is_expected.to eql %w(subject_most subject_least) }
-      end
-    end
-    
-    context 'with a limit' do
-      include_context 'TagsController#popular'
-      it_behaves_like 'TagsController#popular_meta_for', expected_count: 1, expected_limit: 1
-      let(:params){ { section: section, type: 'subject', limit: 1 } }
-      it{ is_expected.to be_successful }
-      
-      describe 'response' do
-        subject{ tag_names }
-        it{ is_expected.to eql %w(subject_most) }
       end
     end
   end


### PR DESCRIPTION
Breaks out serializers and maps both to the same endpoint.

Closes #54 

Provides

All tags for a specific subject
GET /tags?taggable_id=123&taggable_type=Subject

Popular tags for any source:
GET /tags/popular

Most popular tags for subjects on a project:
GET /tags/popular?taggable_type=Subject&section=project-123

Most popular tags for a specific subject:
GET /tags/popular?taggable_type=Subject&taggable_id=123

Subjects by most common tag usage -- find all subjects with a tag, ordered by most usages
GET /tags/popular?name=whatever&taggable_type=Subject

@aweiksnar This does have a breaking change -- renaming the root of the /tags/popular responses to 'popular' instead of 'tags'.

@DarrenMcRoy this will support most of the stuff we had discussed previously about tags