### PR TITLE
Disable sidekiq in default supervisor config

### DIFF
--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -8,11 +8,3 @@ command=/rails_app/docker/start.sh
 redirect_stderr=true
 autostart=true
 autorestart=true
-
-[program:sidekiq]
-user=root
-directory=/rails_app
-command=bundle exec sidekiq
-redirect_stderr=true
-autostart=true
-autorestart=true


### PR DESCRIPTION
I've set up all the necessary stuff in infrastructure to run this on the dump worker instances, so that sidekiq doesn't slow down the API.