### PR TITLE
use ENV var configs by default

### DIFF
--- a/config/initializers/zoo_stream.rb
+++ b/config/initializers/zoo_stream.rb
@@ -2,9 +2,9 @@ if Rails.env.staging? || Rails.env.production?
   require 'aws-sdk'
   require 'zoo_stream'
   Aws.config.update region: 'us-east-1'
-  ZooStream.source = "talk-#{ Rails.env }"
+  ZooStream.source = ENV["ZOO_STREAM_SOURCE"] || "talk"
   publisher = ZooStream::KinesisPublisher.new(
-    stream_name: "zooniverse-#{ Rails.env }",
+    stream_name: ENV["ZOO_STREAM_KINESIS_STREAM_NAME"] || "zooniverse-#{ Rails.env }",
     client: Aws::Kinesis::Client.new({
       http_open_timeout: 5,
       http_read_timeout: 5


### PR DESCRIPTION
default to the env vars, fall back to coded values, also make sure the stream source name matches the expected zoo-event processor models, i.e. talk not talk-env.

The zoo-event stats processor expects known stream source types [here](https://github.com/zooniverse/zoo-event-stats/blob/296e19abf7aef65e49dd706f56bd5f025c89ae4b/lib/models.rb#L14). For ref the zoo_stream gem will default to ENV vars [here](https://github.com/zooniverse/zoo_stream/blob/e2e07ceb9cf392ec0540805ac58dcc762b761c30/lib/zoo_stream.rb#L30) via the `env_file` cmd in docker-compse. 