### PR TITLE
streamline the docker start.sh 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN (cd /rails_app && git log --format="%H" -n 1 > commit_id.txt && rm -rf .git)
 
 EXPOSE 81
 
-ENTRYPOINT /usr/bin/supervisord
+ENTRYPOINT /rails_app/docker/start.sh

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,5 +5,4 @@ then
     ln -s /rails_conf/* /rails_app/config/
 fi
 
-
-exec puma
+exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,6 +5,8 @@ then
     ln -s /rails_conf/* /rails_app/config/
 fi
 
-bundle install --without test development
-rake db:migrate
-puma
+if [ "$RAILS_ENV" == "development" ]; then
+  rake db:migrate
+fi
+
+exec puma

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,8 +5,5 @@ then
     ln -s /rails_conf/* /rails_app/config/
 fi
 
-if [ "$RAILS_ENV" == "development" ]; then
-  rake db:migrate
-fi
 
 exec puma

--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -4,7 +4,7 @@ nodaemon=true
 [program:talk]
 user=root
 directory=/rails_app
-command=/rails_app/docker/start.sh
+command=bundle exec puma
 redirect_stderr=true
 autostart=true
 autorestart=true


### PR DESCRIPTION
don't run bundle install on boot and only run migration on development