### PR TITLE
better configs setup during container start

### DIFF
--- a/docker/migrate.sh
+++ b/docker/migrate.sh
@@ -2,11 +2,6 @@
 
 cd /rails_app
 
-if [ -z "$VAGRANT_APP" ]
-then
-    ln -s /rails_conf/* /rails_app/config/
-fi
-
 if [ -z "$RAILS_ENV" ]
 then
     export RAILS_ENV="production"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -ex
 
-if [ -z "$VAGRANT_APP" ]
-then
-    ln -s /rails_conf/* /rails_app/config/
-fi
+ln -s /rails_conf/* /rails_app/config/ || true
 
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/talk.conf


### PR DESCRIPTION
allow start.sh to symlink the configs on container boot and skip any failures doing so.