### PR TITLE
Ensure the board expression indexes are in the schema.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'honeybadger', '~> 2.6.0'
 gem 'logstasher', '~> 0.9.0'
 gem 'zoo_stream', '~> 1.0'
 gem 'zooniverse_social', '1.0.5'
+gem 'schema_plus_pg_indexes', '~> 0.1.12'
 
 group :production do
   gem 'puma', '~> 3.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     ice_cube (0.13.3)
+    its-it (1.3.0)
     jmespath (1.2.4)
       json_pure (>= 1.8.1)
     json (1.8.6)
@@ -146,6 +147,7 @@ GEM
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    key_struct (0.4.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -169,6 +171,8 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    modware (0.1.3)
+      key_struct (~> 0.4)
     multipart-post (2.0.0)
     naught (1.1.0)
     nenv (0.3.0)
@@ -250,6 +254,22 @@ GEM
     rspec-support (3.4.1)
     ruby_dep (1.3.1)
     safe_yaml (1.0.4)
+    schema_monkey (2.1.5)
+      activerecord (>= 4.2)
+      modware (~> 0.1)
+    schema_plus_core (1.0.2)
+      activerecord (~> 4.2)
+      its-it (~> 1.2)
+      schema_monkey (~> 2.1)
+    schema_plus_indexes (0.2.4)
+      activerecord (>= 4.2, < 5.1)
+      its-it (~> 1.2)
+      schema_plus_core
+    schema_plus_pg_indexes (0.1.12)
+      activerecord (~> 4.2)
+      its-it (~> 1.2)
+      schema_plus_core (~> 1.0)
+      schema_plus_indexes (~> 0.1, >= 0.1.3)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -349,6 +369,7 @@ DEPENDENCIES
   restpack_serializer!
   rspec-its (~> 1.2.0)
   rspec-rails (~> 3.4.2)
+  schema_plus_pg_indexes (~> 0.1.12)
   sdoc (~> 0.4)
   sidekiq (~> 4.1.2)
   sidekiq-congestion (~> 0.1.0)
@@ -363,4 +384,4 @@ DEPENDENCIES
   zooniverse_social (= 1.0.5)
 
 BUNDLED WITH
-   1.13.6
+   1.14.5

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,127 +20,108 @@ ActiveRecord::Schema.define(version: 20170221164834) do
   enable_extension "postgres_fdw"
 
   create_table "announcements", force: :cascade do |t|
-    t.text     "message",    null: false
-    t.string   "section",    null: false
-    t.datetime "expires_at", null: false
-    t.datetime "created_at"
+    t.text     "message",    :null=>false
+    t.string   "section",    :null=>false, :index=>{:name=>"index_announcements_on_section_and_created_at", :with=>["created_at"]}
+    t.datetime "expires_at", :null=>false, :index=>{:name=>"index_announcements_on_expires_at"}
+    t.datetime "created_at", :index=>{:name=>"index_announcements_on_created_at"}
     t.datetime "updated_at"
     t.integer  "project_id"
   end
-
-  add_index "announcements", ["created_at"], name: "index_announcements_on_created_at", using: :btree
-  add_index "announcements", ["expires_at"], name: "index_announcements_on_expires_at", using: :btree
-  add_index "announcements", ["section", "created_at"], name: "index_announcements_on_section_and_created_at", using: :btree
 
   create_table "blocked_users", force: :cascade do |t|
-    t.integer  "user_id",         null: false
-    t.integer  "blocked_user_id", null: false
+    t.integer  "user_id",         :null=>false, :index=>{:name=>"index_blocked_users_on_user_id_and_blocked_user_id", :with=>["blocked_user_id"], :unique=>true}
+    t.integer  "blocked_user_id", :null=>false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
-
-  add_index "blocked_users", ["user_id", "blocked_user_id"], name: "index_blocked_users_on_user_id_and_blocked_user_id", unique: true, using: :btree
 
   create_table "boards", force: :cascade do |t|
-    t.string   "title",                                   null: false
-    t.string   "description",                             null: false
-    t.string   "section",                                 null: false
-    t.integer  "users_count",             default: 0
-    t.integer  "comments_count",          default: 0
-    t.integer  "discussions_count",       default: 0
-    t.json     "permissions",             default: {}
+    t.string   "title",                   :null=>false
+    t.string   "description",             :null=>false
+    t.string   "section",                 :null=>false, :index=>{:name=>"board_order", :with=>["position", "last_comment_created_at"]}
+    t.integer  "users_count",             :default=>0
+    t.integer  "comments_count",          :default=>0
+    t.integer  "discussions_count",       :default=>0
+    t.json     "permissions",             :default=>{}
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "parent_id"
-    t.boolean  "subject_default",         default: false, null: false
+    t.integer  "parent_id",               :index=>{:name=>"sub_board_order", :with=>["position", "last_comment_created_at"]}
+    t.boolean  "subject_default",         :default=>false, :null=>false
     t.integer  "project_id"
     t.datetime "last_comment_created_at"
-    t.integer  "position",                default: 0
+    t.integer  "position",                :default=>0
+    t.index :name=>"boards_read_permission_index", :expression=>"(permissions ->> 'read'::text)"
+    t.index :name=>"boards_write_permission_index", :expression=>"(permissions ->> 'write'::text)"
   end
-
-  add_index "boards", ["parent_id", "position", "last_comment_created_at"], name: "sub_board_order", using: :btree
-  add_index "boards", ["section", "position", "last_comment_created_at"], name: "board_order", using: :btree
-  add_index "boards", ["section", "subject_default"], name: "index_boards_on_section_and_subject_default", unique: true, where: "(subject_default = true)", using: :btree
+  add_index "boards", ["section", "subject_default"], :name=>"index_boards_on_section_and_subject_default", :unique=>true, :where=>"(subject_default = true)"
 
   create_table "comments", force: :cascade do |t|
     t.string   "category"
-    t.text     "body",                             null: false
-    t.integer  "focus_id"
+    t.text     "body",             :null=>false
+    t.integer  "focus_id",         :index=>{:name=>"index_comments_on_focus_id_and_focus_type", :with=>["focus_type"]}
     t.string   "focus_type"
-    t.string   "section",                          null: false
-    t.integer  "discussion_id"
-    t.integer  "user_id",                          null: false
-    t.string   "user_login",                       null: false
-    t.boolean  "is_deleted",       default: false
-    t.json     "versions",         default: []
-    t.datetime "created_at"
+    t.string   "section",          :null=>false, :index=>{:name=>"index_comments_on_section_and_board_id_and_created_at", :with=>["board_id", "created_at"]}
+    t.integer  "discussion_id",    :index=>{:name=>"index_comments_on_discussion_id"}
+    t.integer  "user_id",          :null=>false, :index=>{:name=>"index_comments_on_user_id"}
+    t.string   "user_login",       :null=>false
+    t.boolean  "is_deleted",       :default=>false
+    t.json     "versions",         :default=>[]
+    t.datetime "created_at",       :index=>{:name=>"index_comments_on_created_at"}
     t.datetime "updated_at"
-    t.json     "mentioning",       default: {},    null: false
-    t.json     "tagging",          default: {}
-    t.hstore   "upvotes",          default: {}
+    t.json     "mentioning",       :default=>{}, :null=>false
+    t.json     "tagging",          :default=>{}
+    t.hstore   "upvotes",          :default=>{}
     t.integer  "project_id"
     t.string   "user_ip"
     t.integer  "reply_id"
-    t.integer  "board_id"
-    t.json     "group_mentioning", default: {},    null: false
+    t.integer  "board_id",         :index=>{:name=>"index_comments_on_board_id"}
+    t.json     "group_mentioning", :default=>{}, :null=>false
   end
-
-  add_index "comments", ["board_id", "created_at"], name: "index_comments_on_board_id_and_created_at", using: :btree
-  add_index "comments", ["board_id"], name: "index_comments_on_board_id", using: :btree
-  add_index "comments", ["created_at"], name: "index_comments_on_created_at", using: :btree
-  add_index "comments", ["discussion_id", "created_at"], name: "index_comments_on_discussion_id_and_created_at", using: :btree
-  add_index "comments", ["discussion_id"], name: "index_comments_on_discussion_id", using: :btree
-  add_index "comments", ["focus_id", "focus_type"], name: "index_comments_on_focus_id_and_focus_type", using: :btree
-  add_index "comments", ["section", "board_id", "created_at"], name: "index_comments_on_section_and_board_id_and_created_at", using: :btree
-  add_index "comments", ["section", "created_at"], name: "index_comments_on_section_and_created_at", using: :btree
-  add_index "comments", ["user_id", "created_at"], name: "index_comments_on_user_id_and_created_at", using: :btree
-  add_index "comments", ["user_id"], name: "index_comments_on_user_id", using: :btree
+  add_index "comments", ["board_id", "created_at"], :name=>"index_comments_on_board_id_and_created_at"
+  add_index "comments", ["discussion_id", "created_at"], :name=>"index_comments_on_discussion_id_and_created_at"
+  add_index "comments", ["section", "created_at"], :name=>"index_comments_on_section_and_created_at"
+  add_index "comments", ["user_id", "created_at"], :name=>"index_comments_on_user_id_and_created_at"
 
   create_table "conversations", force: :cascade do |t|
-    t.string   "title",                        null: false
+    t.string   "title",           :null=>false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "participant_ids", default: [],              array: true
+    t.integer  "participant_ids", :default=>[], :array=>true
   end
 
   create_table "data_requests", force: :cascade do |t|
-    t.integer  "user_id",                null: false
-    t.string   "section",                null: false
-    t.string   "kind",                   null: false
-    t.datetime "expires_at",             null: false
+    t.integer  "user_id",    :null=>false
+    t.string   "section",    :null=>false, :index=>{:name=>"index_data_requests_on_section_and_kind_and_user_id", :with=>["kind", "user_id"], :unique=>true}
+    t.string   "kind",       :null=>false
+    t.datetime "expires_at", :null=>false, :index=>{:name=>"index_data_requests_on_expires_at"}
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "state",      default: 0, null: false
+    t.integer  "state",      :default=>0, :null=>false
     t.integer  "project_id"
     t.string   "url"
   end
 
-  add_index "data_requests", ["expires_at"], name: "index_data_requests_on_expires_at", using: :btree
-  add_index "data_requests", ["section", "kind", "user_id"], name: "index_data_requests_on_section_and_kind_and_user_id", unique: true, using: :btree
-
   create_table "discussions", force: :cascade do |t|
-    t.string   "title",                                   null: false
-    t.string   "section",                                 null: false
-    t.integer  "board_id"
-    t.integer  "user_id",                                 null: false
-    t.string   "user_login",                              null: false
-    t.boolean  "sticky",                  default: false
-    t.boolean  "locked",                  default: false
-    t.integer  "users_count",             default: 0
-    t.integer  "comments_count",          default: 0
+    t.string   "title",                   :null=>false
+    t.string   "section",                 :null=>false
+    t.integer  "board_id",                :index=>{:name=>"index_discussions_on_board_id_and_last_comment_created_at", :with=>["last_comment_created_at"]}
+    t.integer  "user_id",                 :null=>false
+    t.string   "user_login",              :null=>false
+    t.boolean  "sticky",                  :default=>false
+    t.boolean  "locked",                  :default=>false
+    t.integer  "users_count",             :default=>0
+    t.integer  "comments_count",          :default=>0
     t.datetime "created_at"
     t.datetime "updated_at"
     t.float    "sticky_position"
-    t.boolean  "subject_default",         default: false, null: false
+    t.boolean  "subject_default",         :default=>false, :null=>false
     t.integer  "project_id"
     t.integer  "focus_id"
     t.string   "focus_type"
     t.datetime "last_comment_created_at"
   end
-
-  add_index "discussions", ["board_id", "last_comment_created_at"], name: "index_discussions_on_board_id_and_last_comment_created_at", using: :btree
-  add_index "discussions", ["board_id", "sticky", "sticky_position"], name: "index_discussions_on_board_id_and_sticky_and_sticky_position", where: "(sticky = true)", using: :btree
-  add_index "discussions", ["board_id", "title", "subject_default"], name: "index_discussions_on_board_id_and_title_and_subject_default", unique: true, where: "(subject_default = true)", using: :btree
+  add_index "discussions", ["board_id", "sticky", "sticky_position"], :name=>"index_discussions_on_board_id_and_sticky_and_sticky_position", :where=>"(sticky = true)"
+  add_index "discussions", ["board_id", "title", "subject_default"], :name=>"index_discussions_on_board_id_and_title_and_subject_default", :unique=>true, :where=>"(subject_default = true)"
 
   create_table "event_logs", force: :cascade do |t|
     t.integer  "user_id"
@@ -152,208 +133,159 @@ ActiveRecord::Schema.define(version: 20170221164834) do
 
   create_table "group_mentions", force: :cascade do |t|
     t.integer  "user_id"
-    t.integer  "comment_id"
+    t.integer  "comment_id", :index=>{:name=>"index_group_mentions_on_comment_id"}
     t.string   "section"
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
-
-  add_index "group_mentions", ["comment_id", "name"], name: "index_group_mentions_on_comment_id_and_name", unique: true, using: :btree
-  add_index "group_mentions", ["comment_id"], name: "index_group_mentions_on_comment_id", using: :btree
+  add_index "group_mentions", ["comment_id", "name"], :name=>"index_group_mentions_on_comment_id_and_name", :unique=>true
 
   create_table "mentions", force: :cascade do |t|
-    t.integer  "mentionable_id",   null: false
-    t.string   "mentionable_type", null: false
-    t.integer  "comment_id",       null: false
-    t.integer  "user_id",          null: false
+    t.integer  "mentionable_id",   :null=>false, :index=>{:name=>"index_mentions_on_unique_per_comment", :with=>["mentionable_type", "comment_id"], :unique=>true}
+    t.string   "mentionable_type", :null=>false
+    t.integer  "comment_id",       :null=>false, :index=>{:name=>"index_mentions_on_comment_id"}
+    t.integer  "user_id",          :null=>false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "section"
     t.integer  "project_id"
-    t.integer  "board_id"
+    t.integer  "board_id",         :index=>{:name=>"index_mentions_on_board_id"}
   end
-
-  add_index "mentions", ["board_id"], name: "index_mentions_on_board_id", using: :btree
-  add_index "mentions", ["comment_id"], name: "index_mentions_on_comment_id", using: :btree
-  add_index "mentions", ["mentionable_id", "mentionable_type", "comment_id"], name: "index_mentions_on_unique_per_comment", unique: true, using: :btree
-  add_index "mentions", ["mentionable_id", "mentionable_type", "created_at"], name: "mentionable_created_at", using: :btree
-  add_index "mentions", ["mentionable_id", "mentionable_type", "section", "created_at"], name: "mentionable_section_created_at", using: :btree
-  add_index "mentions", ["mentionable_id", "mentionable_type"], name: "index_mentions_on_mentionable_id_and_mentionable_type", using: :btree
+  add_index "mentions", ["mentionable_id", "mentionable_type", "created_at"], :name=>"mentionable_created_at"
+  add_index "mentions", ["mentionable_id", "mentionable_type", "section", "created_at"], :name=>"mentionable_section_created_at"
+  add_index "mentions", ["mentionable_id", "mentionable_type"], :name=>"index_mentions_on_mentionable_id_and_mentionable_type"
 
   create_table "messages", force: :cascade do |t|
-    t.integer  "conversation_id", null: false
-    t.string   "body",            null: false
+    t.integer  "conversation_id", :null=>false, :index=>{:name=>"index_messages_on_conversation_id_and_created_at", :with=>["created_at"]}
+    t.string   "body",            :null=>false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id",         null: false
+    t.integer  "user_id",         :null=>false
     t.string   "user_ip"
   end
 
-  add_index "messages", ["conversation_id", "created_at"], name: "index_messages_on_conversation_id_and_created_at", using: :btree
-
   create_table "moderations", force: :cascade do |t|
-    t.integer  "target_id"
+    t.integer  "target_id",        :index=>{:name=>"index_moderations_on_target_id_and_target_type", :with=>["target_type"]}
     t.string   "target_type"
-    t.integer  "state",            default: 0
-    t.json     "reports",          default: []
-    t.json     "actions",          default: []
+    t.integer  "state",            :default=>0
+    t.json     "reports",          :default=>[]
+    t.json     "actions",          :default=>[]
     t.datetime "actioned_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "section",                       null: false
+    t.string   "section",          :null=>false, :index=>{:name=>"index_moderations_on_section_and_state_and_updated_at", :with=>["state", "updated_at"]}
     t.json     "destroyed_target"
     t.integer  "project_id"
   end
 
-  add_index "moderations", ["section", "state", "updated_at"], name: "index_moderations_on_section_and_state_and_updated_at", using: :btree
-  add_index "moderations", ["target_id", "target_type"], name: "index_moderations_on_target_id_and_target_type", using: :btree
-
   create_table "notifications", force: :cascade do |t|
-    t.integer  "user_id"
-    t.text     "message",                         null: false
-    t.string   "url",                             null: false
-    t.string   "section",                         null: false
-    t.boolean  "delivered",       default: false, null: false
-    t.datetime "created_at"
+    t.integer  "user_id",         :index=>{:name=>"index_notifications_on_user_id_and_created_at", :with=>["created_at"]}
+    t.text     "message",         :null=>false
+    t.string   "url",             :null=>false
+    t.string   "section",         :null=>false
+    t.boolean  "delivered",       :default=>false, :null=>false
+    t.datetime "created_at",      :index=>{:name=>"expiring_index"}
     t.datetime "updated_at"
-    t.integer  "subscription_id",                 null: false
+    t.integer  "subscription_id", :null=>false, :index=>{:name=>"index_notifications_on_subscription_id"}
     t.integer  "project_id"
-    t.integer  "source_id"
+    t.integer  "source_id",       :index=>{:name=>"index_notifications_on_source_id_and_source_type", :with=>["source_type"]}
     t.string   "source_type"
   end
-
-  add_index "notifications", ["created_at"], name: "expiring_index", using: :btree
-  add_index "notifications", ["source_id", "source_type"], name: "index_notifications_on_source_id_and_source_type", using: :btree
-  add_index "notifications", ["subscription_id"], name: "index_notifications_on_subscription_id", using: :btree
-  add_index "notifications", ["user_id", "created_at"], name: "index_notifications_on_user_id_and_created_at", using: :btree
-  add_index "notifications", ["user_id", "delivered", "created_at"], name: "unread_index", using: :btree
-  add_index "notifications", ["user_id", "section", "created_at"], name: "index_notifications_on_user_id_and_section_and_created_at", using: :btree
-  add_index "notifications", ["user_id", "section", "delivered", "created_at"], name: "unread_section_index", using: :btree
+  add_index "notifications", ["user_id", "delivered", "created_at"], :name=>"unread_index"
+  add_index "notifications", ["user_id", "section", "created_at"], :name=>"index_notifications_on_user_id_and_section_and_created_at"
+  add_index "notifications", ["user_id", "section", "delivered", "created_at"], :name=>"unread_section_index"
 
   create_table "roles", force: :cascade do |t|
-    t.integer  "user_id",                   null: false
-    t.string   "section",                   null: false
-    t.string   "name",                      null: false
+    t.integer  "user_id",    :null=>false, :index=>{:name=>"index_roles_on_user_id_and_section_and_is_shown", :with=>["section", "is_shown"]}
+    t.string   "section",    :null=>false
+    t.string   "name",       :null=>false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "is_shown",   default: true, null: false
+    t.boolean  "is_shown",   :default=>true, :null=>false
   end
-
-  add_index "roles", ["user_id", "section", "is_shown"], name: "index_roles_on_user_id_and_section_and_is_shown", using: :btree
-  add_index "roles", ["user_id", "section", "name"], name: "index_roles_on_user_id_and_section_and_name", unique: true, using: :btree
+  add_index "roles", ["user_id", "section", "name"], :name=>"index_roles_on_user_id_and_section_and_name", :unique=>true
 
   create_table "searchable_boards", primary_key: "searchable_id", force: :cascade do |t|
-    t.string   "searchable_type",              null: false
-    t.tsvector "content",         default: "", null: false
-    t.string   "sections",        default: [], null: false, array: true
+    t.string   "searchable_type", :null=>false, :index=>{:name=>"index_searchable_boards_on_searchable_type"}
+    t.tsvector "content",         :default=>"", :null=>false, :index=>{:name=>"index_searchable_boards_on_content", :using=>:gin}
+    t.string   "sections",        :default=>[], :null=>false, :array=>true, :index=>{:name=>"index_searchable_boards_on_sections", :using=>:gin}
   end
-
-  add_index "searchable_boards", ["content"], name: "index_searchable_boards_on_content", using: :gin
-  add_index "searchable_boards", ["searchable_type"], name: "index_searchable_boards_on_searchable_type", using: :btree
-  add_index "searchable_boards", ["sections"], name: "index_searchable_boards_on_sections", using: :gin
 
   create_table "searchable_comments", primary_key: "searchable_id", force: :cascade do |t|
-    t.string   "searchable_type",              null: false
-    t.tsvector "content",         default: "", null: false
-    t.string   "sections",        default: [], null: false, array: true
+    t.string   "searchable_type", :null=>false, :index=>{:name=>"index_searchable_comments_on_searchable_type"}
+    t.tsvector "content",         :default=>"", :null=>false, :index=>{:name=>"index_searchable_comments_on_content", :using=>:gin}
+    t.string   "sections",        :default=>[], :null=>false, :array=>true, :index=>{:name=>"index_searchable_comments_on_sections", :using=>:gin}
   end
-
-  add_index "searchable_comments", ["content"], name: "index_searchable_comments_on_content", using: :gin
-  add_index "searchable_comments", ["searchable_type"], name: "index_searchable_comments_on_searchable_type", using: :btree
-  add_index "searchable_comments", ["sections"], name: "index_searchable_comments_on_sections", using: :gin
 
   create_table "searchable_discussions", primary_key: "searchable_id", force: :cascade do |t|
-    t.string   "searchable_type",              null: false
-    t.tsvector "content",         default: "", null: false
-    t.string   "sections",        default: [], null: false, array: true
+    t.string   "searchable_type", :null=>false, :index=>{:name=>"index_searchable_discussions_on_searchable_type"}
+    t.tsvector "content",         :default=>"", :null=>false, :index=>{:name=>"index_searchable_discussions_on_content", :using=>:gin}
+    t.string   "sections",        :default=>[], :null=>false, :array=>true, :index=>{:name=>"index_searchable_discussions_on_sections", :using=>:gin}
   end
-
-  add_index "searchable_discussions", ["content"], name: "index_searchable_discussions_on_content", using: :gin
-  add_index "searchable_discussions", ["searchable_type"], name: "index_searchable_discussions_on_searchable_type", using: :btree
-  add_index "searchable_discussions", ["sections"], name: "index_searchable_discussions_on_sections", using: :gin
 
   create_table "subscription_preferences", force: :cascade do |t|
-    t.integer  "category",                    null: false
-    t.integer  "user_id",                     null: false
-    t.integer  "email_digest", default: 0,    null: false
-    t.boolean  "enabled",      default: true, null: false
+    t.integer  "category",     :null=>false
+    t.integer  "user_id",      :null=>false, :index=>{:name=>"index_subscription_preferences_on_user_id_and_category", :with=>["category"]}
+    t.integer  "email_digest", :default=>0, :null=>false
+    t.boolean  "enabled",      :default=>true, :null=>false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
-
-  add_index "subscription_preferences", ["user_id", "category"], name: "index_subscription_preferences_on_user_id_and_category", using: :btree
 
   create_table "subscriptions", force: :cascade do |t|
-    t.integer  "category",                   null: false
-    t.integer  "user_id",                    null: false
-    t.integer  "source_id",                  null: false
-    t.string   "source_type",                null: false
+    t.integer  "category",    :null=>false
+    t.integer  "user_id",     :null=>false, :index=>{:name=>"index_subscriptions_on_user_id_and_category", :with=>["category"]}
+    t.integer  "source_id",   :null=>false, :index=>{:name=>"index_subscriptions_on_source_id_and_source_type", :with=>["source_type"]}
+    t.string   "source_type", :null=>false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "enabled",     default: true, null: false
+    t.boolean  "enabled",     :default=>true, :null=>false
   end
-
-  add_index "subscriptions", ["source_id", "source_type"], name: "index_subscriptions_on_source_id_and_source_type", using: :btree
-  add_index "subscriptions", ["user_id", "category"], name: "index_subscriptions_on_user_id_and_category", using: :btree
-  add_index "subscriptions", ["user_id", "source_id", "source_type", "category"], name: "index_subscriptions_uniquely", unique: true, using: :btree
-  add_index "subscriptions", ["user_id", "source_id", "source_type"], name: "index_subscriptions_on_user_id_and_source_id_and_source_type", using: :btree
+  add_index "subscriptions", ["user_id", "source_id", "source_type", "category"], :name=>"index_subscriptions_uniquely", :unique=>true
+  add_index "subscriptions", ["user_id", "source_id", "source_type"], :name=>"index_subscriptions_on_user_id_and_source_id_and_source_type"
 
   create_table "suggested_tags", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",       :index=>{:name=>"index_suggested_tags_on_name_and_section", :with=>["section"], :unique=>true}
     t.string   "section"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "suggested_tags", ["name", "section"], name: "index_suggested_tags_on_name_and_section", unique: true, using: :btree
-
   create_table "tags", force: :cascade do |t|
-    t.string   "name",          null: false
-    t.string   "section",       null: false
+    t.string   "name",          :null=>false
+    t.string   "section",       :null=>false, :index=>{:name=>"index_tags_on_section_and_taggable_type_and_name", :with=>["taggable_type", "name"]}
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id",       null: false
-    t.integer  "comment_id",    null: false
-    t.integer  "taggable_id"
+    t.integer  "user_id",       :null=>false
+    t.integer  "comment_id",    :null=>false, :index=>{:name=>"index_tags_on_comment_id"}
+    t.integer  "taggable_id",   :index=>{:name=>"index_tags_on_taggable_id_and_taggable_type", :with=>["taggable_type"]}
     t.string   "taggable_type"
     t.integer  "project_id"
     t.string   "user_login"
   end
-
-  add_index "tags", ["comment_id", "name"], name: "index_tags_on_comment_id_and_name", unique: true, using: :btree
-  add_index "tags", ["comment_id"], name: "index_tags_on_comment_id", using: :btree
-  add_index "tags", ["section", "taggable_type", "name"], name: "index_tags_on_section_and_taggable_type_and_name", using: :btree
-  add_index "tags", ["section", "taggable_type"], name: "index_tags_on_section_and_taggable_type", using: :btree
-  add_index "tags", ["taggable_id", "taggable_type"], name: "index_tags_on_taggable_id_and_taggable_type", using: :btree
+  add_index "tags", ["comment_id", "name"], :name=>"index_tags_on_comment_id_and_name", :unique=>true
+  add_index "tags", ["section", "taggable_type"], :name=>"index_tags_on_section_and_taggable_type"
 
   create_table "unsubscribe_tokens", force: :cascade do |t|
-    t.integer  "user_id",    null: false
-    t.string   "token",      null: false
-    t.datetime "expires_at", null: false
+    t.integer  "user_id",    :null=>false, :index=>{:name=>"index_unsubscribe_tokens_on_user_id", :unique=>true}
+    t.string   "token",      :null=>false, :index=>{:name=>"index_unsubscribe_tokens_on_token", :unique=>true}
+    t.datetime "expires_at", :null=>false, :index=>{:name=>"index_unsubscribe_tokens_on_expires_at"}
   end
-
-  add_index "unsubscribe_tokens", ["expires_at"], name: "index_unsubscribe_tokens_on_expires_at", using: :btree
-  add_index "unsubscribe_tokens", ["token"], name: "index_unsubscribe_tokens_on_token", unique: true, using: :btree
-  add_index "unsubscribe_tokens", ["user_id"], name: "index_unsubscribe_tokens_on_user_id", unique: true, using: :btree
 
   create_table "user_conversations", force: :cascade do |t|
-    t.integer  "user_id",                        null: false
-    t.integer  "conversation_id",                null: false
-    t.boolean  "is_unread",       default: true
+    t.integer  "user_id",         :null=>false
+    t.integer  "conversation_id", :null=>false, :index=>{:name=>"unread_user_conversations", :with=>["user_id", "is_unread"]}
+    t.boolean  "is_unread",       :default=>true
     t.datetime "created_at"
     t.datetime "updated_at"
   end
-
-  add_index "user_conversations", ["conversation_id", "user_id", "is_unread"], name: "unread_user_conversations", using: :btree
-  add_index "user_conversations", ["conversation_id", "user_id"], name: "index_user_conversations_on_conversation_id_and_user_id", using: :btree
+  add_index "user_conversations", ["conversation_id", "user_id"], :name=>"index_user_conversations_on_conversation_id_and_user_id"
 
   create_table "user_ip_bans", force: :cascade do |t|
-    t.cidr     "ip",         null: false
+    t.cidr     "ip",         :null=>false, :index=>{:name=>"index_user_ip_bans_on_ip"}
     t.datetime "created_at"
     t.datetime "updated_at"
   end
-
-  add_index "user_ip_bans", ["ip"], name: "index_user_ip_bans_on_ip", using: :btree
 
 end


### PR DESCRIPTION
Moved from the postgres 9.5 `if exists` sql syntax to rails index helpers and in the process preserved the expression indexes in the schema.rb via the schema_plus_pg_indexes gem. It was that or move to a sql dump format and modify the test setup scripts, etc.

Unfortunately it modified the schema file format which is a pretty verbose diff :( but we now have those indexes preserved in the schema.rb file :)