### PR TITLE
Change conversation.updated-at timestamp when new message is created

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,7 +2,7 @@ class Message < ActiveRecord::Base
   include Notifiable
 
   belongs_to :user, required: true
-  belongs_to :conversation, required: true
+  belongs_to :conversation, required: true, touch: true
   has_many :user_conversations, through: :conversation
   has_many :users, through: :user_conversations
 

--- a/spec/services/message_service_spec.rb
+++ b/spec/services/message_service_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe MessageService, type: :service do
     it_behaves_like 'a service creating', Message do
       let(:recipients){ conversation.users - [current_user] }
 
+
+
       it 'should set the user ip' do
         expect(service.build.user_ip).to eql '1.2.3.4'
       end
@@ -39,6 +41,9 @@ RSpec.describe MessageService, type: :service do
       before(:each){ service.create }
       subject{ service.resource }
       its(:user){ is_expected.to eql current_user }
+      it 'should change the conversations updated_at timestamp' do
+        expect { service.build }.to change { conversation.updated_at }
+      end
     end
   end
 end

--- a/spec/services/message_service_spec.rb
+++ b/spec/services/message_service_spec.rb
@@ -36,11 +36,16 @@ RSpec.describe MessageService, type: :service do
     end
 
     context 'creating the message' do
-      before(:each){ service.create }
-      subject{ service.resource }
-      its(:user){ is_expected.to eql current_user }
-      it 'should change the conversations updated_at timestamp' do
-        expect { service.build }.to change { conversation.reload.updated_at }
+      let(:service_resource) { service.resource }
+
+      it "should set the current user" do
+        created_service = service.create
+        expect(service_resource.user).to eql(current_user)
+      end
+
+      it 'should update the conversations timestamp' do
+        conversation
+        expect { service.create }.to change { conversation.reload.updated_at }
       end
     end
   end

--- a/spec/services/message_service_spec.rb
+++ b/spec/services/message_service_spec.rb
@@ -36,11 +36,9 @@ RSpec.describe MessageService, type: :service do
     end
 
     context 'creating the message' do
-      let(:service_resource) { service.resource }
-
       it "should set the current user" do
-        created_service = service.create
-        expect(service_resource.user).to eql(current_user)
+        service.create
+        expect(service.resource.user).to eql(current_user)
       end
 
       it 'should update the conversations timestamp' do

--- a/spec/services/message_service_spec.rb
+++ b/spec/services/message_service_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe MessageService, type: :service do
     it_behaves_like 'a service creating', Message do
       let(:recipients){ conversation.users - [current_user] }
 
-
-
       it 'should set the user ip' do
         expect(service.build.user_ip).to eql '1.2.3.4'
       end
@@ -42,7 +40,7 @@ RSpec.describe MessageService, type: :service do
       subject{ service.resource }
       its(:user){ is_expected.to eql current_user }
       it 'should change the conversations updated_at timestamp' do
-        expect { service.build }.to change { conversation.updated_at }
+        expect { service.build }.to change { conversation.reload.updated_at }
       end
     end
   end


### PR DESCRIPTION
Attempts to fix #113 
Test `spec/services/message_service_spec.rb` fails, probably because I'm missing something.