### PR TITLE
suggested tag completion fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Then start everything up with
 ```
 
 If you're running outside of vagrant and just want to run the specs ensure you've created the foreign
-data tables not in the *schema.rb* file via `RACK_ENV=test bundle exec rake panoptes:db:create_tables`, see *.travis.yml* for more details.
+data tables not in the *schema.rb* file via the following (see *.travis.yml* for more details):
+  0. `RACK_ENV=test bundle exec rake panoptes:db:create_tables`
+  0. `RACK_ENV=test bundle exec rake panoptes:db:setup`
 
 ## Layout
 

--- a/lib/tag_completion.rb
+++ b/lib/tag_completion.rb
@@ -77,7 +77,7 @@ class TagCompletion
         (#{ popular_matching_tags }) popular_matching_tags
 
       order by
-        score desc
+        name, score desc
     SQL
   end
 

--- a/lib/tag_completion.rb
+++ b/lib/tag_completion.rb
@@ -143,18 +143,15 @@ class TagCompletion
     connection.execute(
       <<-SQL
         select set_limit(0.1);
-        select max(usages)
-        from (
-        select count(distinct(user_id)) usages
+        select count(distinct(user_id)) max_usages
 
         from tags
 
         where
           section = #{ @section } and
           name % #{ @name }
-        ) matching
       SQL
-    ).to_a.first['max']
+    ).to_a.first['max_usages']
   end
 
   def sanitize(string)


### PR DESCRIPTION
closes #123 

Ensure the suggested tags have the highest score and thus show up first in the UI list. Simple reason was the merge of used suggested tags kept the lower score and thus they didn't sort to the top. 

See reason for ordering for distinct selection here: https://stackoverflow.com/questions/16913969/postgres-distinct-but-only-for-one-column