### PR TITLE
Add project title to comment serializer

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,3 +1,5 @@
 class Project < ActiveRecord::Base
   has_many :boards
+
+  alias_attribute :title, :display_name
 end

--- a/app/serializers/concerns/embedded_attributes.rb
+++ b/app/serializers/concerns/embedded_attributes.rb
@@ -22,7 +22,7 @@ module EmbeddedAttributes
   end
 
   def project_attributes
-    %w(slug)
+    %w(slug title)
   end
 
   def custom_attributes
@@ -35,12 +35,27 @@ module EmbeddedAttributes
 
   def attributes_from(relation)
     { }.tap do |attrs|
-      record_attributes = model.send(relation).attributes rescue { }
+      record_attributes = relation_record_attributes_and_aliases(
+        model.send(relation)
+      )
+
       send("#{ relation }_attributes").each do |attr|
         value = record_attributes[attr]
         value = value.to_s if attr =~ /(_id)|(^id$)$/
         attrs[:"#{ relation }_#{ attr }"] = value
       end
+    end
+  end
+
+  def relation_record_attributes_and_aliases(relation_record)
+    if relation_record
+      aliased_attrs = {}
+      relation_record.attribute_aliases.each do |key, aliased_attr|
+        aliased_attrs[key] = relation_record.send(aliased_attr)
+      end
+      relation_record.attributes.merge(aliased_attrs)
+    else
+      {}
     end
   end
 end

--- a/spec/support/shared_examples_for_embedded_attributes.rb
+++ b/spec/support/shared_examples_for_embedded_attributes.rb
@@ -37,6 +37,7 @@ RSpec.shared_examples_for 'a serializer with embedded attributes' do |relations:
     describe '#project_attributes' do
       subject{ json }
       its([:project_slug]){ is_expected.to eql model_instance.project.slug }
+      its([:project_title]){ is_expected.to eql model_instance.project.title }
     end
   end
 end


### PR DESCRIPTION
linked to https://github.com/zooniverse/Panoptes-Front-End/pull/4735

Embed the `project.title` when serializing the comment resource. 

As there is no access to the `project_contents` table via the FDW in talk db, we instead use the panoptes `project.display_name` as the `project.title` as it is analogous to the `project.project_contents.title`.