### PR TITLE
add moderation report wording and links to talk notifications

### DIFF
--- a/app/views/notification_mailer/notify.html.erb
+++ b/app/views/notification_mailer/notify.html.erb
@@ -44,7 +44,10 @@
           <% notifications.each do |notification| %>
             <%= container do %>
               <div>
-                <%= link_to notification.message, notification.url, style: link_style %>
+                <h4>notification.message</h4>
+                <div>
+                  <%= link_to 'View report moderation tools', notification.url, style: link_style %>
+                </div>
                 <% if notification.source.target_type == 'Comment' %>
                   <div>
                     <%= link_to 'View comment on talk', FrontEnd.link_to(notification.source.target), style: link_style %>

--- a/app/views/notification_mailer/notify.text.erb
+++ b/app/views/notification_mailer/notify.text.erb
@@ -31,8 +31,14 @@ Zooniverse Talk Notifications:
 <% end %>
 
 <% notifications.each do |notification| %>
-      <%= notification.message %>: <%= notification.url %>
+      <%= notification.message %>
+      View report moderation tools: <%= notification.url %>
+      <% if notification.source.target_type == 'Comment' %>
 
+        View comment on talk: <%= FrontEnd.link_to(notification.source.target) %>
+
+        <%= time_ago_in_words notification.source.created_at %> ago
+      <% end %>
 <% end %>
 <% end %>
 <% end %>


### PR DESCRIPTION
clarify the wording and links in talk moderation reports so users can find the moderation tools via links.