### PR TITLE
move commit_id.txt to public for access via web

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -4,4 +4,9 @@ tmpreaper 7d /tmp/
 
 ln -s /rails_conf/* /rails_app/config/ || true
 
+if [ -f "commit_id.txt" ]
+then
+  cp commit_id.txt public/
+fi
+
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/talk.conf


### PR DESCRIPTION
linked to https://github.com/zooniverse/operations/pull/165

Allow the talk commit id to be publicly accessible via nginx. this will allow us to inspect the state of the deployed API via HTTP requests and use in chat ops, etc.