### PR TITLE
Add Pull Reminders Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The new backend for Talk
 [![Build Status](https://travis-ci.org/zooniverse/Talk-Api.svg?branch=master)](https://travis-ci.org/zooniverse/Talk-Api)
 [![Code Climate](https://codeclimate.com/github/zooniverse/Talk-Api/badges/gpa.svg)](https://codeclimate.com/github/zooniverse/Talk-Api)
 [![Test Coverage](https://codeclimate.com/github/zooniverse/Talk-Api/badges/coverage.svg)](https://codeclimate.com/github/zooniverse/Talk-Api)
+[![pullreminders](https://pullreminders.com/badge.svg)](https://pullreminders.com?ref=badge)
 
 ## Setting up
 
@@ -111,5 +112,3 @@ Check the [issues](https://github.com/zooniverse/Talk-Api/issues) for what's in 
 Copyright 2014-2015 by the Zooniverse
 
 Distributed under the Apache Public License v2. See [LICENSE](LICENSE)
-
-[![pullreminders](https://pullreminders.com/badge.svg)](https://pullreminders.com?ref=badge)

--- a/README.md
+++ b/README.md
@@ -111,3 +111,5 @@ Check the [issues](https://github.com/zooniverse/Talk-Api/issues) for what's in 
 Copyright 2014-2015 by the Zooniverse
 
 Distributed under the Apache Public License v2. See [LICENSE](LICENSE)
+
+[![pullreminders](https://pullreminders.com/badge.svg)](https://pullreminders.com?ref=badge)


### PR DESCRIPTION
This PR adds support for [Pull Reminders](https://pullreminders.com/?utm_source=github&utm_medium=marketplace) by including a badge on the README. More info on the badge [here](https://pullreminders.com/badge).