### PR TITLE
allow translator role in board creation

### DIFF
--- a/app/schemas/board_schema.rb
+++ b/app/schemas/board_schema.rb
@@ -35,7 +35,7 @@ class BoardSchema
 
   def permission(obj, name)
     obj.entity name, required: true do
-      enum [:all, :team, :moderator, :admin]
+      enum [:all, :team, :moderator, :admin, :translator]
     end
   end
 end

--- a/spec/schemas/board_schema_spec.rb
+++ b/spec/schemas/board_schema_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe BoardSchema, type: :schema do
           its(:required){ is_expected.to eql %w(read write) }
 
           with :properties do
-            its(:read){ is_expected.to eql enum: %w(all team moderator admin) }
-            its(:write){ is_expected.to eql enum: %w(all team moderator admin) }
+            its(:read){ is_expected.to eql enum: %w(all team moderator admin translator) }
+            its(:write){ is_expected.to eql enum: %w(all team moderator admin translator) }
           end
         end
       end


### PR DESCRIPTION
fixes #188 - allow translator role to be set when creating boards. 

I'm not sure why this set of roles is different to the roles allowed when updating board perms, https://github.com/zooniverse/Talk-Api/blob/9b56fca32998328fb0afef8be586749b442c46c6/app/schemas/role_schema.rb#L26