### PR TITLE
consolidate supervisor logs to app log dir

### DIFF
--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -1,5 +1,6 @@
 [supervisord]
 nodaemon=true
+childlogdir=/rails_app/log/
 
 [program:talk]
 user=root


### PR DESCRIPTION
Make the logs visible in the app log dir. Currently logging to `/tmp/talk-stdout-supervisor*.log` which i couldn't find when debugging app start