### PR TITLE
Add secrets.yml

### DIFF
--- a/.guardrails/ignore
+++ b/.guardrails/ignore
@@ -1,2 +1,3 @@
 docker-compose.yml
 config/database.yml
+config/secrets.yml

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,11 @@
+development:
+  secret_key_base: f5fcde6513a07ba1c68ce659554d42563ecb9bfb31e887e209fc0279f4d88f84e9c8e5c35b0e00acc9353cf9d33c8a754dbbceffb71cdaf759664303be39e734
+
+test:
+  secret_key_base: f5fcde6513a07ba1c68ce659554d42563ecb9bfb31e887e209fc0279f4d88f84e9c8e5c35b0e00acc9353cf9d33c8a754dbbceffb71cdaf759664303be39e734
+
+staging:
+  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
+
+production:
+  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>


### PR DESCRIPTION
Staging is failing with:

```
#<RuntimeError: Missing `secret_token` and `secret_key_base` for 'staging' environment, set these values in `config/secrets.yml`>
```

From looking at Panoptes, I don't think I need to explicitly define `secret_token`, but let me know if I'm wrong.