### PR TITLE
update the puma config

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -2,7 +2,7 @@
 
 app_path = File.expand_path(File.dirname(File.dirname(__FILE__)))
 dev_env = 'development'
-rails_env = ENV['RAILS_ENV'] || dev_env
+rails_env = ENV.fetch('RAILS_ENV', dev_env)
 port = rails_env == dev_env ? 3000 : 81
 threads_count = ENV.fetch('RAILS_MAX_THREADS', 2).to_i
 
@@ -12,4 +12,3 @@ state_path "#{app_path}/tmp/pids/puma.state"
 threads 1, threads_count
 bind "tcp://0.0.0.0:#{port}"
 tag 'talk_api'
-

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,10 +1,15 @@
-#!/usr/bin/env puma
+# frozen_string_literal: true
 
-if ENV['RAILS_ENV'] !~ /development|test/
-  directory '/rails_app'
-end
+app_path = File.expand_path(File.dirname(File.dirname(__FILE__)))
+dev_env = 'development'
+rails_env = ENV['RAILS_ENV'] || dev_env
+port = rails_env == dev_env ? 3000 : 81
+threads_count = ENV.fetch('RAILS_MAX_THREADS', 2).to_i
 
-threads 1, ENV.fetch('RAILS_MAX_THREADS', 2).to_i
-worker_timeout 10
+# PUMA DSL settings
+pidfile "#{app_path}/tmp/pids/server.pid"
+state_path "#{app_path}/tmp/pids/puma.state"
+threads 1, threads_count
+bind "tcp://0.0.0.0:#{port}"
+tag 'talk_api'
 
-bind 'tcp://0.0.0.0:81'


### PR DESCRIPTION
Align the talk puma config with other puma APIs - specifically remove the worker_timeout as i believe this is causing the API to fall over for long running queries.

+ remove the worker_timeout
+ add tag for known process
+ allow ports to be different for the dev / deployed envs
+ track pid / state in local tmp files