### PR TITLE
Increase CPU request and limit

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -50,10 +50,10 @@ spec:
           resources:
             requests:
               memory: "750Mi"
-              cpu: "10m"
+              cpu: "500m"
             limits:
               memory: "750Mi"
-              cpu: "500m"
+              cpu: "1000m"
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
I think we've under estimated these.

This is related to why the app is scaling up so much I think (scaling is based on the percentage it's using of the limits we've defined, so if the limits are too low then the app will scale more).