### PR TITLE
Serve static assets via nginx reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN bundle install --without development test
 
 ADD ./ /rails_app
 
-RUN (cd /rails_app && git log --format="%H" -n 1 > commit_id.txt && rm -rf .git)
+RUN (git log --format="%H" -n 1 > /rails_app/public/commit_id.txt && rm -rf .git)
 
 EXPOSE 81
 

--- a/README.md
+++ b/README.md
@@ -8,48 +8,23 @@ The new backend for Talk
 [![pullreminders](https://pullreminders.com/badge.svg)](https://pullreminders.com?ref=badge)
 
 ## Setting up
-
-* Ruby 2.2
-
-* [Vagrant](https://www.vagrantup.com/downloads.html)
-
 * Docker
   * [OS X](https://docs.docker.com/installation/mac/) - Boot2Docker
   * [Ubuntu](https://docs.docker.com/installation/ubuntulinux/) - Docker
   * [Windows](http://docs.docker.com/installation/windows/) - Boot2Docker
 
-By default, Vagrant runs in the staging environment, so you'll want to add configurations:
+Build & start the docker containers:
 
-* database.yml
-  ```yaml
-    staging:
-      adapter: postgresql
-      encoding: unicode
-      pool: 5
-      database: talk_staging
-      username: talk
-      host: <%= ENV['PG_PORT_5432_TCP_ADDR'] %>
-      password: <%= ENV['TALK_DB_PASSWORD'] %>
-  ```
-
-* panoptes.yml
-  ```yaml
-    staging:
-      host: 'https://panoptes-staging.zooniverse.org'
-  ```
-
-* secrets.yml
-  ```yaml
-    staging:
-      secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
-  ```
-
-Then start everything up with
 ```
-  bundle
-  vagrant up
+  docker-compose build
+  docker-compose up
   open http://localhost:3000/
 ```
+
+Alternatively use docker to run a testing environment bash shell and run test commands, run:
+
+1. `docker-compose run --service-ports --rm -e RAILS_ENV=test talkapi bash`
+0. `bundle exec rspec` from the container bash shell run
 
 If you're running outside of vagrant and just want to run the specs ensure you've created all the databases and tables(foreign) via the following commands:
 1. `RACK_ENV=test bundle exec rake db:create`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,6 @@ talkapi:
     - "RAILS_ENV=development"
     - "DATABASE_URL=postgresql://talkapi:talkapi@pg"
     - "REDIS_URL=redis://redis:6379/0"
-  # external_links:
-  #   - external_postgres_container:pg
   links:
     - postgres:pg
     - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 postgres:
-  image: postgres
+  image: postgres:9.5
   environment:
     - "POSTGRES_USER=talkapi"
     - "POSTGRES_PASSWORD=talkapi"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -2,13 +2,6 @@
 
 tmpreaper 7d /tmp/
 
-ln -s /rails_conf/* /rails_app/config/ || true
-
-if [ -f "commit_id.txt" ]
-then
-  cp commit_id.txt public/
-fi
-
 cd /rails_app
 mkdir -p tmp/pids
 rm -f tmp/pids/*.pid

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -14,7 +14,7 @@ data:
       proxy_set_header X-Real-IP $remote_addr;
 
       location = /commit_id.txt {
-        root /talk_rails_app_public/;
+        root /static-assets/;
         expires off;
         add_header 'Access-Control-Allow-Origin' '*';
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, HEAD';
@@ -76,6 +76,13 @@ spec:
               name: talk-staging-env-vars
           - configMapRef:
               name: talk-staging-shared
+          volumeMounts:
+            - name: static-assets
+              mountPath: "/static-assets"
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/bash", "-c", "cp -R /rails_app/public/* /static-assets"]
         - name: talk-staging-nginx
           image: zooniverse/nginx:1.19.0
           resources:
@@ -109,9 +116,16 @@ spec:
           ports:
             - containerPort: 80
           volumeMounts:
+            - name: static-assets
+              mountPath: "/static-assets"
             - name: talk-nginx-config
               mountPath: "/etc/nginx-sites"
       volumes:
+        - name: static-assets
+          hostPath:
+            # directory location on host node temp disk
+            path: /mnt/talk-staging-app-static-assets
+            type: DirectoryOrCreate
         - name: talk-nginx-config
           configMap:
             name: talk-nginx-conf-staging
@@ -199,8 +213,8 @@ spec:
           - configMapRef:
               name: talk-staging-shared
           volumeMounts:
-          - mountPath: /tmp
-            name: talk-staging-dumpworker-data
+            - mountPath: /tmp
+              name: talk-staging-dumpworker-data
       volumes:
         - name: talk-staging-dumpworker-data
           hostPath:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -213,8 +213,8 @@ spec:
           - configMapRef:
               name: talk-staging-shared
           volumeMounts:
-            - mountPath: /tmp
-              name: talk-staging-dumpworker-data
+          - mountPath: /tmp
+            name: talk-staging-dumpworker-data
       volumes:
         - name: talk-staging-dumpworker-data
           hostPath:


### PR DESCRIPTION
specifically the commit_id.txt but this PR change allows any rails app public files to be served via nginx

This PR also updates the readme for cmd to use docker for testing and the docker-compose file to specify postgres v9.5 image (what we're running in prod)