### PR TITLE
Include mailer.yml for development env & container building

### DIFF
--- a/config/mailer.yml
+++ b/config/mailer.yml
@@ -1,0 +1,8 @@
+development:
+  enable_starttls_auto: true
+  address:
+  port:
+  domain:
+  authentication:
+  user_name:
+  password:


### PR DESCRIPTION
Rails won't start and tests can't be run in a Docker container built with a dev environment without this file.