### PR TITLE
Set host before attempting request

### DIFF
--- a/spec/lib/markdown_api_spec.rb
+++ b/spec/lib/markdown_api_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe MarkdownApi, type: :lib do
   end
 
   describe '.markdown' do
+    before(:each){ ENV['MARKDOWN_HOST'] = 'http://markdown.localhost' }
     let(:body){ '**test** _markdown_' }
     let(:slug){ 'foo/bar' }
     let!(:stubbed_request) do


### PR DESCRIPTION
Fixes local spec failure for MarkdownApi by setting the host env var before attempting request.