### PR TITLE
Add conditional to only set_content on existing searchables

### DIFF
--- a/lib/tasks/update_search_tsvectors.rake
+++ b/lib/tasks/update_search_tsvectors.rake
@@ -30,7 +30,7 @@ namespace :search do
       puts "Processing #{klass}s..."
       klass.find_in_batches(start: start_id, batch_size: batch_size).with_index do |resources, batch|
         puts "Processing batch ##{batch}, starting on id #{resources.first.id}"
-        resources.map { |res| res&.searchable.set_content }
+        resources.map { |res| res.searchable.set_content if res.searchable }
 
         # Checkpoint the id of the last resource in the batch in Redis
         checkpoint_record_id = comments.last.id


### PR DESCRIPTION
OK so safety first and all but turns out I should just only set_content if the searchable exists and not worry about nils at all.