### PR TITLE
Tweak the HPA scaling metrics for more accurate pod replica counts

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -194,7 +194,7 @@ spec:
           resources:
             requests:
               memory: "700Mi"
-              cpu: "50m"
+              cpu: "250m"
               ephemeral-storage: "1Gi"
             limits:
               memory: "700Mi"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -50,7 +50,7 @@ spec:
           resources:
             requests:
               memory: "200Mi"
-              cpu: "10m"
+              cpu: "100m"
             limits:
               memory: "200Mi"
               cpu: "500m"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -193,7 +193,7 @@ spec:
           resources:
             requests:
               memory: "700Mi"
-              cpu: "50m"
+              cpu: "100m"
               ephemeral-storage: "1Gi"
             limits:
               memory: "700Mi"


### PR DESCRIPTION
Ensure our talk service pod replica counts better reflect actual CPU workload. Run less pods, save on RAM & CPU pressure while maintaining our service response times.