### PR TITLE
switch pdb to percent of available replicas

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -165,7 +165,7 @@ kind: PodDisruptionBudget
 metadata:
    name: talk-production-app-pdb
 spec:
-  minAvailable: 2
+  minAvailable: 50%
   selector:
     matchLabels:
       app: talk-production-app
@@ -250,7 +250,7 @@ kind: PodDisruptionBudget
 metadata:
    name: talk-production-sidekiq-pdb
 spec:
-  minAvailable: 1
+  minAvailable: 50%
   selector:
     matchLabels:
       app: talk-production-sidekiq


### PR DESCRIPTION
avoid hard coding the number of PDB replicas, instead use a percent of the available replicas https://kubernetes.io/docs/tasks/run-application/configure-pdb/

This allows more lenient eviction rules for the relevant pods. I came across pods that wouldn't evict due to the PDB settings when doing the cluster / node pool upgrades the other day. Specifically from https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
> If you set maxUnavailable to 0% or 0, or you set minAvailable to 100% or the number of replicas, you are requiring zero voluntary evictions. When you set zero voluntary evictions for a workload object such as ReplicaSet, then you cannot successfully drain a Node running one of those Pods. If you try to drain a Node where an unevictable Pod is running, the drain never completes. This is permitted as per the semantics of PodDisruptionBudget.
