### PR TITLE
update honeybadger notify method call

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,7 @@ module Talk
 
   def self.report_error(e)
     if Rails.env.staging? || Rails.env.production?
-      Honeybadger.notify_or_ignore e
+      Honeybadger.notify(e)
     end
   end
 


### PR DESCRIPTION
this method name was renamed in v3 to `.notify(e)`
https://github.com/honeybadger-io/honeybadger-ruby/blob/master/CHANGELOG.md#removed-2