### PR TITLE
Upgrade readiness & liveness probes for k8s pods

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -59,15 +59,19 @@ spec:
               path: /
               port: 81
               httpHeaders:
-                 - name: X-Forwarded-Proto
-                   value: https
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: Accept
+                  value: application/json
           readinessProbe:
             httpGet:
               path: /
               port: 81
               httpHeaders:
-                 - name: X-Forwarded-Proto
-                   value: https
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: Accept
+                  value: application/json
             initialDelaySeconds: 20
           envFrom:
           - secretRef:
@@ -97,16 +101,20 @@ spec:
               path: /
               port: 80
               httpHeaders:
-                 - name: X-Forwarded-Proto
-                   value: https
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: Accept
+                  value: application/json
             initialDelaySeconds: 10
           readinessProbe:
             httpGet:
               path: /
-              port: 81
+              port: 80
               httpHeaders:
-                 - name: X-Forwarded-Proto
-                   value: https
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: Accept
+                  value: application/json
             initialDelaySeconds: 20
           lifecycle:
             preStop:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -101,20 +101,20 @@ spec:
               path: /
               port: 80
               httpHeaders:
-                 - name: X-Forwarded-Proto
-                   value: https
-                 - name: Accept
-                   value: application/json
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: Accept
+                  value: application/json
             initialDelaySeconds: 10
           readinessProbe:
             httpGet:
               path: /
-              port: 81
+              port: 80
               httpHeaders:
-                 - name: X-Forwarded-Proto
-                   value: https
-                 - name: Accept
-                   value: application/json
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: Accept
+                  value: application/json
             initialDelaySeconds: 20
           lifecycle:
             preStop:


### PR DESCRIPTION
upgrade liveness and readiness probes for staging & production to use the correct nginx ports (runs on port 80 not 81) and use json mime type headers to ensure the responses are 200 and not 301 redirects

