### PR TITLE
remove length constraints on FDW project varchar fields

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -53,8 +53,8 @@ namespace :panoptes do
       ActiveRecord::Base.connection.execute <<-SQL
         create foreign table if not exists projects (
           id int4,
-          display_name varchar(255),
-          slug varchar(255),
+          display_name varchar,
+          slug varchar,
           private bool,
           launch_approved bool,
           launched_row_order int4


### PR DESCRIPTION
panoptes db doesn't have length constraints so talk fdw should not enforce any for row values that may exceed this and thus error

https://github.com/zooniverse/panoptes/blob/4b3c799f796214c033ed57fda2c2ddcbe7693a7e/db/structure.sql#L1027-L1041

I tested this locally by building the docker images and creating local versions of the db with the instructions in https://github.com/zooniverse/talk-api/#setting-up. Everything is working well and matches with the changes on the production system.
