### PR TITLE
Update k8s pod resource requests and limits

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -49,8 +49,8 @@ spec:
           image: zooniverse/talk-api:__IMAGE_TAG__
           resources:
             requests:
-              memory: "750Mi"
-              cpu: "500m"
+              memory: "200Mi"
+              cpu: "100m"
             limits:
               memory: "750Mi"
               cpu: "1000m"
@@ -91,11 +91,11 @@ spec:
           image: zooniverse/nginx:1.19.0
           resources:
             requests:
-              memory: "100Mi"
+              memory: "30Mi"
               cpu: "10m"
             limits:
               memory: "100Mi"
-              cpu: "1000m"
+              cpu: "500m"
           livenessProbe:
             httpGet:
               path: /
@@ -211,11 +211,11 @@ spec:
           image: zooniverse/talk-api:__IMAGE_TAG__
           resources:
             requests:
-              memory: "700Mi"
-              cpu: "250m"
+              memory: "250Mi"
+              cpu: "50m"
             limits:
               memory: "700Mi"
-              cpu: "500m"
+              cpu: "1000m"
           livenessProbe:
             exec:
               command:

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -213,11 +213,9 @@ spec:
             requests:
               memory: "700Mi"
               cpu: "250m"
-              ephemeral-storage: "1Gi"
             limits:
               memory: "700Mi"
               cpu: "500m"
-              ephemeral-storage: "1Gi"
           livenessProbe:
             exec:
               command:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -49,10 +49,10 @@ spec:
           image: zooniverse/talk-api:__IMAGE_TAG__
           resources:
             requests:
-              memory: "200Mi"
-              cpu: "100m"
+              memory: "150Mi"
+              cpu: "10m"
             limits:
-              memory: "200Mi"
+              memory: "250Mi"
               cpu: "500m"
           livenessProbe:
             httpGet:
@@ -91,7 +91,7 @@ spec:
           image: zooniverse/nginx:1.19.0
           resources:
             requests:
-              memory: "100Mi"
+              memory: "30Mi"
               cpu: "10m"
             limits:
               memory: "100Mi"
@@ -200,13 +200,11 @@ spec:
           image: zooniverse/talk-api:__IMAGE_TAG__
           resources:
             requests:
-              memory: "700Mi"
-              cpu: "100m"
-              ephemeral-storage: "1Gi"
+              memory: "200Mi"
+              cpu: "30m"
             limits:
-              memory: "700Mi"
+              memory: "500Mi"
               cpu: "500m"
-              ephemeral-storage: "1Gi"
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
Help with node scheduling and avoid running more k8s nodes that we need.

- Remove the ephemeral-storage limits (allow the worker to fill the disk and error if there is an issue with space**)
- update the requests based on value inspection from `kubectl top pod --containers | grep talk`

** the tmp storage on those k8s nodes is 150GB so lots of room now so no need to limit