### PR TITLE
reset K8s cpu requests

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -50,7 +50,7 @@ spec:
           resources:
             requests:
               memory: "200Mi"
-              cpu: "100m"
+              cpu: "500m"
             limits:
               memory: "750Mi"
               cpu: "1000m"
@@ -212,7 +212,7 @@ spec:
           resources:
             requests:
               memory: "250Mi"
-              cpu: "50m"
+              cpu: "250m"
             limits:
               memory: "700Mi"
               cpu: "1000m"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -50,7 +50,7 @@ spec:
           resources:
             requests:
               memory: "150Mi"
-              cpu: "10m"
+              cpu: "100m"
             limits:
               memory: "250Mi"
               cpu: "500m"
@@ -201,7 +201,7 @@ spec:
           resources:
             requests:
               memory: "200Mi"
-              cpu: "30m"
+              cpu: "100m"
             limits:
               memory: "500Mi"
               cpu: "500m"


### PR DESCRIPTION
these are used to for HPA scaling metrics so smaller values here will mean a lower scaling threshold being met and thus will increase the number of running pods resulting in more resource pressure on the k8s nodes and thus increase the cluster scaling pressure.
