### PR TITLE
Use slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /rails_app
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
+    build-essential \
     git \
     libpq-dev \
     tmpreaper \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM ruby:2.5-slim
 
 WORKDIR /rails_app
 
-RUN apt-get update && \
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+    apt-get update && \
     apt-get install --no-install-recommends -y \
     build-essential \
     git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.5-slim
 
 WORKDIR /rails_app
 


### PR DESCRIPTION
shrink the overall image size and the number of packages in the underlying image (and thus the security surface)

Also adds the new buildkit caching feature to cache the apt package manager installs as outlined in https://vsupalov.com/docker-buildkit-features/ and specifically https://github.com/moby/buildkit/blob/2a4577efabed1b4404e2884ef56873b8c0a42e95/frontend/dockerfile/docs/syntax.md#example-cache-apt-packages