### PR TITLE
update apt cache mount for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,13 @@ WORKDIR /rails_app
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
-RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,id=talk-apt-cache,target=/var/cache/apt --mount=type=cache,id=talk-apt-lib,target=/var/lib/apt \
     apt-get update && \
     apt-get install --no-install-recommends -y \
     build-essential \
     git \
     libpq-dev \
-    tmpreaper \
-    && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    tmpreaper
 
 ARG RAILS_ENV=production
 


### PR DESCRIPTION
linked to https://github.com/zooniverse/panoptes/pull/3637#discussion_r710048330

- add cache mount ids to isolate between repos
- remove the apt-clean step as we want to reuse the apt cache data between builds, https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypecache