### PR TITLE
allow owners to access boards with translator roles

### DIFF
--- a/app/policies/board_policy.rb
+++ b/app/policies/board_policy.rb
@@ -49,11 +49,16 @@ class BoardPolicy < ApplicationPolicy
 
     def for_roles
       user_roles.collect do |section, roles|
+        roles << 'translator' if translator_for?(roles)
         roles << 'team' if team_for?(section)
-        roles << 'moderator' if 'admin'.in?(roles)
+        roles << 'moderator' if 'admin'.in?(roles) # admin is the owner role for the section
         quoted_roles = roles.uniq.collect{ |role| quote role }.join ', '
         "(boards.permissions ->> '#{ @permission }' in (#{ quoted_roles }) and boards.section = #{ quote section })"
       end
+    end
+
+    def translator_for?(roles)
+      'admin'.in?(roles) || 'moderator'.in?(roles) || 'scientist'.in?(roles) || 'translator'.in?(roles)
     end
 
     def team_for?(section)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -36,5 +36,15 @@ FactoryGirl.define do
         user.roles.create section: evaluator.section, name: 'scientist'
       end
     end
+
+    factory :translator do
+      transient do
+        section 'project-1'
+      end
+
+      after :create do |user, evaluator|
+        user.roles.create section: evaluator.section, name: 'translator'
+      end
+    end
   end
 end

--- a/spec/policies/board_policy_spec.rb
+++ b/spec/policies/board_policy_spec.rb
@@ -29,6 +29,44 @@ RSpec.describe BoardPolicy, type: :policy do
     end
   end
 
+  context 'with permissions read:translator write:translator' do
+    let(:record){ create :board, section: 'project-1', permissions: { read: 'translator', write: 'translator' } }
+
+    context 'without a user' do
+      it_behaves_like 'a policy excluding'
+      it_behaves_like 'a policy forbidding', :show, :create, :update, :destroy
+    end
+
+    context 'with a user' do
+      let(:user){ create :user }
+      it_behaves_like 'a policy excluding'
+      it_behaves_like 'a policy forbidding', :show, :create, :update, :destroy
+    end
+
+    context 'with a translator' do
+      let(:user){ create :translator }
+      it_behaves_like 'a policy forbidding', :create, :update, :destroy
+      it_behaves_like 'a policy permitting', :index, :show
+    end
+
+    context 'with a team member' do
+      let(:user){ create :scientist }
+      it_behaves_like 'a policy excluding'
+      it_behaves_like 'a policy forbidding', :create, :update, :destroy
+      it_behaves_like 'a policy permitting', :index, :show
+    end
+
+    context 'with a moderator' do
+      let(:user){ create :moderator }
+      it_behaves_like 'a policy permitting', :index, :show, :create, :update, :destroy
+    end
+
+    context 'with an admin' do
+      let(:user){ create :admin }
+      it_behaves_like 'a policy permitting', :index, :show, :create, :update, :destroy
+    end
+  end
+
   context 'with permissions read:team write:team' do
     let(:record){ create :board, section: 'project-1', permissions: { read: 'team', write: 'team' } }
 


### PR DESCRIPTION
This PR adds the role authorization checks to ensure that project owners and team members can access boards with the translator role read /write permissions

Permissions cascade so anyone with project owner or team rights can see board with translator role. Those user's with only translator role users can only see the boards with translator or lower (public) permissions setup.