### PR TITLE
Implement posting age requirement

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -84,9 +84,8 @@ class ApplicationPolicy
     end
 
     def age_requirement
-      req = ENV.fetch('POSTING_AGE_REQUIREMENT', '1 week')
-      quant, duration = req.split(' ')
-      quant.to_i.send(duration)
+      quant = ENV.fetch('POSTING_AGE_REQUIREMENT', '24')
+      quant.to_i.hours
     end
 
     def roles_in(section)

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -77,6 +77,18 @@ class ApplicationPolicy
       true
     end
 
+    def of_posting_age?
+      return true unless ENV['POSTING_AGE_REQUIREMENT']
+
+      user.created_at < (Time.now - age_requirement)
+    end
+
+    def age_requirement
+      req = ENV.fetch('POSTING_AGE_REQUIREMENT', '1 week')
+      quant, duration = req.split(' ')
+      quant.to_i.send(duration)
+    end
+
     def roles_in(section)
       user_roles.fetch section, []
     end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -10,7 +10,7 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def create?
-    logged_in? && !locked? && writable?
+    logged_in? && !locked? && writable? && of_posting_age?
   end
 
   def update?

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -10,7 +10,11 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def create?
-    logged_in? && !locked? && writable? && of_posting_age?
+    if Array.wrap(record).compact.any? { |a| a.section == 'zooniverse' }
+      logged_in? && !locked? && writable? && of_posting_age?
+    else
+      logged_in? && !locked? && writable?
+    end
   end
 
   def update?

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
     email { "#{ login }@example.com" }
     admin false
     banned false
+    created_at Time.now - 1.year
 
     factory :moderator do
       transient do

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -20,10 +20,26 @@ RSpec.describe ApplicationPolicy, type: :policy do
   end
 
   context 'with a user' do
+    ENV['POSTING_AGE_REQUIREMENT'] = '1 week'
     let(:user){ create :user }
     let(:record){ OpenStruct.new user_id: user.id + 1, section: 'project-1' }
 
     it{ is_expected.to be_logged_in }
+    it{ is_expected.to be_of_posting_age }
+    it{ is_expected.to_not be_owner }
+    it{ is_expected.to_not be_moderator }
+    it{ is_expected.to_not be_admin }
+    it{ is_expected.to_not be_team }
+    it{ is_expected.to have_attributes user_roles: { } }
+  end
+
+  context 'with a brand new user' do
+    ENV['POSTING_AGE_REQUIREMENT'] = '1 week'
+
+    let(:user){ create :user, created_at: Time.now }
+
+    it{ is_expected.to be_logged_in }
+    it{ is_expected.to_not be_of_posting_age }
     it{ is_expected.to_not be_owner }
     it{ is_expected.to_not be_moderator }
     it{ is_expected.to_not be_admin }

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ApplicationPolicy, type: :policy do
   end
 
   context 'with a user' do
-    ENV['POSTING_AGE_REQUIREMENT'] = '1 week'
+    ENV['POSTING_AGE_REQUIREMENT'] = '24'
     let(:user){ create :user }
     let(:record){ OpenStruct.new user_id: user.id + 1, section: 'project-1' }
 
@@ -34,8 +34,7 @@ RSpec.describe ApplicationPolicy, type: :policy do
   end
 
   context 'with a brand new user' do
-    ENV['POSTING_AGE_REQUIREMENT'] = '1 week'
-
+    ENV['POSTING_AGE_REQUIREMENT'] = '24'
     let(:user){ create :user, created_at: Time.now }
 
     it{ is_expected.to be_logged_in }

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -40,10 +40,19 @@ RSpec.describe CommentPolicy, type: :policy do
     end
 
     context 'with a new account' do
-      ENV['POSTING_AGE_REQUIREMENT'] = '1 week'
       let(:user){ create :user, created_at: Time.now }
-      it_behaves_like 'a policy permitting', :index, :show, :upvote, :remove_upvote
-      it_behaves_like 'a policy forbidding', :create, :update, :destroy, :move
+      ENV['POSTING_AGE_REQUIREMENT'] = '24'
+
+      context 'on a project board' do
+        it_behaves_like 'a policy permitting', :index, :show, :create, :upvote, :remove_upvote
+        it_behaves_like 'a policy forbidding', :update, :destroy, :move
+      end
+
+      context 'on the zooniverse board' do
+        let(:board){ create :board, section: 'zooniverse', permissions: { read: 'all', write: 'all' } }
+        it_behaves_like 'a policy permitting', :index, :show, :upvote, :remove_upvote
+        it_behaves_like 'a policy forbidding', :create, :update, :destroy, :move
+      end
     end
   end
 

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe CommentPolicy, type: :policy do
       it_behaves_like 'a policy permitting', :index, :show, :create, :move, :upvote, :remove_upvote
       it_behaves_like 'a policy forbidding', :update, :destroy
     end
+
+    context 'with a new account' do
+      ENV['POSTING_AGE_REQUIREMENT'] = '1 week'
+      let(:user){ create :user, created_at: Time.now }
+      it_behaves_like 'a policy permitting', :index, :show, :upvote, :remove_upvote
+      it_behaves_like 'a policy forbidding', :create, :update, :destroy, :move
+    end
   end
 
   context 'with permissions read:team write:team' do


### PR DESCRIPTION
Adds the length of time since a user's created_at timestamp as a policy check to determine whether that user can post new comments. Direct result of spam issues on Talk. 

This requires a new env var, `'POSTING_AGE_REQUIREMENT'`, to exist in order to be checked. This is a string that represents the number of hours old an account has to be to be allowed to post a comment on specifically the 'zooniverse' board. Default is 24.

Before merging this PR and deploying this feature, we should have a follow up conversation.