### PR TITLE
Email verification

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -77,6 +77,10 @@ class ApplicationPolicy
       true
     end
 
+    def confirmed?
+      !!user.confirmed_at
+    end
+
     def of_posting_age?
       return true unless ENV['POSTING_AGE_REQUIREMENT']
 

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -11,18 +11,18 @@ class CommentPolicy < ApplicationPolicy
 
   def create?
     if Array.wrap(record).compact.any? { |c| c.discussion.board.section == 'zooniverse' }
-      logged_in? && !locked? && writable? && of_posting_age?
+      logged_in? && !locked? && writable? && confirmed? && of_posting_age?
     else
-      logged_in? && !locked? && writable?
+      logged_in? && !locked? && writable? && confirmed?
     end
   end
 
   def update?
-    owner? && !deleted? && !locked? && writable?
+    owner? && !deleted? && !locked? && writable? && confirmed?
   end
 
   def destroy?
-    owner? && !deleted? && !locked? && writable?
+    owner? && !deleted? && !locked? && writable? && confirmed?
   end
 
   def move?

--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -1,14 +1,14 @@
 class ConversationPolicy < ApplicationPolicy
   def index?
-    logged_in?
+    logged_in? && confirmed?
   end
 
   def show?
-    moderator? || admin? || participant?
+    (moderator? || admin? || participant?) && confirmed?
   end
 
   def create?
-    logged_in?
+    logged_in? && confirmed?
   end
 
   def update?
@@ -16,7 +16,7 @@ class ConversationPolicy < ApplicationPolicy
   end
 
   def destroy?
-    participant?
+    participant? && confirmed?
   end
 
   class Scope < Scope

--- a/app/policies/discussion_policy.rb
+++ b/app/policies/discussion_policy.rb
@@ -11,9 +11,9 @@ class DiscussionPolicy < ApplicationPolicy
 
   def create?
     if Array.wrap(record).compact.any? { |d| d.board.section == 'zooniverse' }
-      writable? && of_posting_age?
+      writable? && confirmed? && of_posting_age?
     else
-      writable?
+      writable? && confirmed?
     end
   end
 

--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -1,14 +1,14 @@
 class MessagePolicy < ApplicationPolicy
   def index?
-    logged_in?
+    logged_in? && confirmed?
   end
 
   def show?
-    moderator? || admin? || participant?
+    (moderator? || admin? || participant?) && confirmed?
   end
 
   def create?
-    participant?
+    participant? && confirmed?
   end
 
   def update?

--- a/db/migrate/20231107211623_add_confirmed_to_users.rb
+++ b/db/migrate/20231107211623_add_confirmed_to_users.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddConfirmedToUsers < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      ALTER FOREIGN TABLE users ADD COLUMN confirmed_at TIMESTAMP DEFAULT NULL
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER FOREIGN TABLE users DROP COLUMN IF EXISTS confirmed_at;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180518132406) do
+ActiveRecord::Schema.define(version: 20231107211623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -79,7 +79,8 @@ namespace :panoptes do
           zooniverse_id varchar(255),
           credited_name varchar(255),
           admin bool,
-          banned bool
+          banned bool,
+          confirmed_at timestamp(6)
         ) server panoptes;
 
         create foreign table if not exists oauth_access_tokens (
@@ -232,7 +233,8 @@ namespace :panoptes do
           banned boolean default false not null,
           migrated boolean default false,
           valid_email boolean default true not null,
-          uploaded_subjects_count integer default 0
+          uploaded_subjects_count integer default 0,
+          confirmed_at timestamp(6) without time zone default null
         );
 
         drop table if exists oauth_access_tokens;

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     admin false
     banned false
     created_at Time.now - 1.year
+    confirmed_at Time.now - 364.days
 
     factory :moderator do
       transient do

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe CommentPolicy, type: :policy do
       it_behaves_like 'a policy forbidding', :update, :destroy
     end
 
+    context 'with an unconfirmed user' do
+      let(:user){ create :user, confirmed_at: nil }
+      it_behaves_like 'a policy permitting', :index, :show, :upvote, :remove_upvote
+      it_behaves_like 'a policy forbidding', :update, :destroy, :move
+    end
+
     context 'with a new account' do
       let(:user){ create :user, created_at: Time.now }
       ENV['POSTING_AGE_REQUIREMENT'] = '24'

--- a/spec/policies/conversation_policy_spec.rb
+++ b/spec/policies/conversation_policy_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe ConversationPolicy, type: :policy do
     it_behaves_like 'a policy forbidding', :show, :update, :destroy
   end
 
+  context 'with an unconfirmed user' do
+    let(:user){ create :user, confirmed_at: nil }
+    it_behaves_like 'a policy forbidding', :index, :show, :create, :destroy, :update
+  end
+
   context 'with a participant' do
     let(:user){ record.users.first }
     it_behaves_like 'a policy permitting', :index, :show, :create, :destroy

--- a/spec/policies/discussion_policy_spec.rb
+++ b/spec/policies/discussion_policy_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe DiscussionPolicy, type: :policy do
       it_behaves_like 'a policy forbidding', :create, :update, :destroy
     end
 
+    context 'with an unconfirmed user' do
+      let(:user){ create :user, confirmed_at: nil }
+      let(:board){ create :board, section: 'zooniverse', permissions: { read: 'all', write: 'all' } }
+      it_behaves_like 'a policy permitting', :index, :show
+      it_behaves_like 'a policy forbidding', :create, :update, :destroy
+    end
+
     context 'with the owner' do
       let(:user){ record.user }
       it_behaves_like 'a policy permitting', :index, :show, :create, :update

--- a/spec/policies/message_policy_spec.rb
+++ b/spec/policies/message_policy_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe MessagePolicy, type: :policy do
     it_behaves_like 'a policy forbidding', :show, :create, :update, :destroy
   end
 
+  context 'with an unconfirmed user' do
+    let(:user){ create :user, confirmed_at: nil }
+    it_behaves_like 'a policy forbidding', :index, :show, :create, :update, :destroy
+  end
+
   context 'with a participant' do
     let(:user){ record.user }
     it_behaves_like 'a policy permitting', :index, :show, :create


### PR DESCRIPTION
Adds support for the Panoptes user table attribute `confirmed_at`; a not-null `confirmed_at` attr indicates that the user has confirmed their email address. Includes checks of this attribute on all boards for the following action policies:

Discussions: create
Comments: create, update, destroy
Conversations: index, show, create, destroy
Messages: index, show, create

This seems to follow the intentions of both the initial policies and the new restrictions. This could have been done at a higher level (closer to the application controller) where entire verbs would be blocked similarly to how bans are handled. However, this lacks the finer grain control of policies and introduces considerably more complexity in testing. This feels like a good compromise and is similar to how the account age requirement for posting was handled.

This PR requires the corresponding Panoptes PR to merge first. The couple of them will need some hands on testing on staging.