### PR TITLE
Email verification: Require confirmation to invoke message & conversation workers

### DIFF
--- a/app/controllers/concerns/action_rescuing.rb
+++ b/app/controllers/concerns/action_rescuing.rb
@@ -29,6 +29,7 @@ module ActionRescuing
     rescue_from Talk::BannedUserError, with: :forbidden
     rescue_from Talk::BlockedUserError, with: :forbidden
     rescue_from Talk::UserBlockedError, with: :forbidden
+    rescue_from Talk::UserUnconfirmedError, with: :forbidden
     rescue_from OauthAccessToken::ExpiredError, with: :unauthorized
     rescue_from OauthAccessToken::RevokedError, with: :unauthorized
   end

--- a/app/services/conversation_service.rb
+++ b/app/services/conversation_service.rb
@@ -13,6 +13,7 @@ class ConversationService < ApplicationService
 
     raise Talk::BlockedUserError.new if blocked?
     raise Talk::UserBlockedError.new if blocking?
+    raise Talk::UserUnconfirmedError.new if unconfirmed?
     recipient_ids.each do |recipient_id|
       conversation.user_conversations.build user_id: recipient_id, is_unread: true
     end
@@ -47,5 +48,9 @@ class ConversationService < ApplicationService
 
   def blocking?
     BlockedUser.blocked_by(current_user.id).blocking(recipient_ids).exists?
+  end
+
+  def unconfirmed?
+    current_user.confirmed_at.nil?
   end
 end

--- a/app/services/message_service.rb
+++ b/app/services/message_service.rb
@@ -6,6 +6,7 @@ class MessageService < ApplicationService
       built.user_ip = user_ip
       raise Talk::BlockedUserError.new if blocked?
       raise Talk::UserBlockedError.new if blocking?
+      raise Talk::UserUnconfirmedError.new if unconfirmed?
     end
   end
 
@@ -17,6 +18,11 @@ class MessageService < ApplicationService
   def blocking?
     return false unless resource.conversation
     BlockedUser.blocked_by(current_user.id).blocking(recipient_ids).exists?
+  end
+
+  def unconfirmed?
+    return false unless resource.conversation
+    current_user.confirmed_at.nil?
   end
 
   def recipient_ids

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,13 @@ module Talk
     alias_method :to_s, :message
   end
 
+  class UserUnconfirmedError < StandardError
+    def message
+      'You must confirm your account'
+    end
+    alias_method :to_s, :message
+  end
+
   class InvalidParameterError < StandardError
     def initialize(param, expected, actual)
       @param = param

--- a/spec/services/conversation_service_spec.rb
+++ b/spec/services/conversation_service_spec.rb
@@ -69,6 +69,13 @@ RSpec.describe ConversationService, type: :service do
           expect{ service.build }.to raise_error Talk::UserBlockedError
         end
       end
+
+      context 'when the sender is unconfirmed' do
+        it 'should fail' do
+          current_user.confirmed_at = nil
+          expect{ service.build }.to raise_error Talk::UserUnconfirmedError
+        end
+      end
     end
   end
 end

--- a/spec/services/message_service_spec.rb
+++ b/spec/services/message_service_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe MessageService, type: :service do
           expect{ service.build }.to raise_error Talk::UserBlockedError
         end
       end
+
+      context 'when the user is unconfirmed' do
+        it 'should fail' do
+          current_user.confirmed_at = nil
+          expect{ service.build }.to raise_error Talk::UserUnconfirmedError
+        end
+      end
     end
 
     context 'creating the message' do


### PR DESCRIPTION
Make sure the message and conversation services don't run if the user is unconfirmed.