### PR TITLE
prevent notification emails from being sent to user's with invalid email

### DIFF
--- a/app/workers/notification_email_worker.rb
+++ b/app/workers/notification_email_worker.rb
@@ -14,6 +14,9 @@ class NotificationEmailWorker
 
   def perform(user_id, digest)
     user = ::User.find user_id
+
+    return unless user.valid_email
+
     digest_number = SubscriptionPreference.email_digests[digest]
 
     # Ensure there are categories delivered at this frequency

--- a/db/migrate/20240402094638_add_valid_email_to_users.rb
+++ b/db/migrate/20240402094638_add_valid_email_to_users.rb
@@ -1,0 +1,13 @@
+class AddValidEmailToUsers < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      ALTER FOREIGN TABLE users ADD COLUMN valid_email boolean DEFAULT true;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER FOREIGN TABLE users DROP COLUMN IF EXISTS valid_email;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20231107211623) do
+ActiveRecord::Schema.define(version: 20240402094638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -80,6 +80,7 @@ namespace :panoptes do
           credited_name varchar(255),
           admin bool,
           banned bool,
+          valid_email bool,
           confirmed_at timestamp(6)
         ) server panoptes;
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     admin false
     banned false
     created_at Time.now - 1.year
+    valid_email true
     confirmed_at Time.now - 364.days
 
     factory :moderator do

--- a/spec/workers/notification_email_worker_spec.rb
+++ b/spec/workers/notification_email_worker_spec.rb
@@ -71,5 +71,15 @@ RSpec.describe NotificationEmailWorker, type: :worker do
         worker.perform user.id, :daily
       end
     end
+
+    context 'when user email is invalid' do
+      it 'should not attempt to deliver email' do
+        user.update(valid_email: false)
+        mail = double deliver_now!: true
+        expect(NotificationMailer).not_to receive(:notify)
+        expect(mail).not_to receive :deliver_now!
+        worker.perform user.id, :daily
+      end
+    end
   end
 end


### PR DESCRIPTION
Solves for this issue: https://github.com/zooniverse/talk-api/issues/312