### PR TITLE
Rails 5 - Missing env on GH Action, Update Run Test CI so that 2.6 runs with 5.0 not 4.2

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -35,6 +35,8 @@ jobs:
             ruby: 2.6
           - gemfile: Gemfile.next
             ruby: 2.5
+    env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
+      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
missing env for github workflow run so bundler installs from correct gemfile

**Context**: CI tests for 2.6 currently are running with Rails 4.2 which gets ThreadErrors. Wanted behavior is for CI tests for 2.6/Gemfile.next to bundle install from Gemfile.next and not Gemfile. For this, we need a missing env key that I missed in [first PR of Dual Boot.](https://github.com/zooniverse/talk-api/pull/318)


See latest test run here: https://github.com/zooniverse/talk-api/actions/runs/9247077764/job/25508402312?pr=323

More importantly note: 
```
Called from /home/runner/work/talk-api/talk-api/vendor/bundle/ruby/2.6.0/gems/activesupport-4.2.11.3/lib/active_support/dependencies.rb:240:in `load_dependency'
```