### PR TITLE
rails 5.0 upgrade: make content-type header application/json

### DIFF
--- a/spec/support/shared_examples_for_controller_updating.rb
+++ b/spec/support/shared_examples_for_controller_updating.rb
@@ -8,6 +8,7 @@ RSpec.shared_examples_for 'a controller updating' do
 
   before :each do
     allow(subject).to receive(:current_user).and_return current_user
+    request.headers['CONTENT_TYPE'] = 'application/json'
   end
 
   describe '#update' do


### PR DESCRIPTION
- Issue was caused as the ’sticky’ boolean was converted to a string and therefore fails the schema validation
- Making the request header CONTENT_TYPE be application/json fixes this
