### PR TITLE
Rails 5 fix user conversation and blocked user tests

### DIFF
--- a/spec/models/blocked_user_spec.rb
+++ b/spec/models/blocked_user_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe BlockedUser, type: :model do
   context 'validating' do
     it 'should require a user' do
       without_user = build :blocked_user, user: nil
-      expect(without_user).to fail_validation user: "can't be blank"
+      expect(without_user).to fail_validation user: $required_validation_text
     end
 
     it 'should require a blocked_user' do
       without_blocked_user = build :blocked_user, blocked_user: nil
-      expect(without_blocked_user).to fail_validation blocked_user: "can't be blank"
+      expect(without_blocked_user).to fail_validation blocked_user: $required_validation_text
     end
   end
 

--- a/spec/models/blocked_user_spec.rb
+++ b/spec/models/blocked_user_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe BlockedUser, type: :model do
   context 'validating' do
     it 'should require a user' do
       without_user = build :blocked_user, user: nil
-      expect(without_user).to fail_validation user: $required_validation_text
+      expect(without_user).to fail_validation
     end
 
     it 'should require a blocked_user' do
       without_blocked_user = build :blocked_user, blocked_user: nil
-      expect(without_blocked_user).to fail_validation blocked_user: $required_validation_text
+      expect(without_blocked_user).to fail_validation
     end
   end
 

--- a/spec/models/user_conversation_spec.rb
+++ b/spec/models/user_conversation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UserConversation, type: :model do
   context 'validating' do
     it 'should require a user' do
       without_user = build :user_conversation, user_id: nil
-      expect(without_user).to fail_validation user: $required_validation_text
+      expect(without_user).to fail_validation
     end
   end
 

--- a/spec/models/user_conversation_spec.rb
+++ b/spec/models/user_conversation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UserConversation, type: :model do
   context 'validating' do
     it 'should require a user' do
       without_user = build :user_conversation, user_id: nil
-      expect(without_user).to fail_validation user: "can't be blank"
+      expect(without_user).to fail_validation user: $required_validation_text
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,8 @@ PanoptesUser = User # Since RSpec/FactoryGirl can't handle multiple databases
 
 Aws.config.update region: 'us-east-1', credentials: Aws::Credentials.new('', '')
 
+$required_validation_text = Rails.version.starts_with?('4.2') ? "can't be blank" : "must exist"
+
 if ENV['EVIL_MODE']
   require 'open-uri'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,6 @@ PanoptesUser = User # Since RSpec/FactoryGirl can't handle multiple databases
 
 Aws.config.update region: 'us-east-1', credentials: Aws::Credentials.new('', '')
 
-
 if ENV['EVIL_MODE']
   require 'open-uri'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,6 @@ PanoptesUser = User # Since RSpec/FactoryGirl can't handle multiple databases
 
 Aws.config.update region: 'us-east-1', credentials: Aws::Credentials.new('', '')
 
-$required_validation_text = Rails.version.starts_with?('4.2') ? "can't be blank" : "must exist"
 
 if ENV['EVIL_MODE']
   require 'open-uri'


### PR DESCRIPTION
This has to do with validation messages. With the upgrade the validation message for associations are now 'must exist' as opposed to 'can't be blank'. 
Added the text on the spec_helper so i can factor in tests on the previous rails version aswell (good idea??)