### PR TITLE
build service before validating

### DIFF
--- a/spec/support/shared_examples_for_services.rb
+++ b/spec/support/shared_examples_for_services.rb
@@ -170,6 +170,7 @@ RSpec.shared_examples_for 'a service creating' do |resource|
 
     it 'should validate the schema' do
       schema = double create: double
+      service.build
       expect(service.schema_class).to receive(:new).and_return schema
       expect(schema.create).to receive(:validate!)
         .with(service.rooted_params)


### PR DESCRIPTION
Issue happens cos `service.rooted_params` is an object that matches the `:create_params` here: https://github.com/zooniverse/talk-api/blob/4347b0ede6adc4cb8f00700c788ed6c5ccf897af/spec/services/discussion_service_spec.rb#L7

However, the validate class receives a different object as rooted_params during validation here:https://github.com/zooniverse/talk-api/blob/4347b0ede6adc4cb8f00700c788ed6c5ccf897af/app/services/concerns/talk_service.rb#L68

The new object has a `user_id` parameter added to both the discussion object and the comment array of objects and that makes it different from the `:create_params`.

I traced down to set_user: https://github.com/zooniverse/talk-api/blob/4347b0ede6adc4cb8f00700c788ed6c5ccf897af/app/services/concerns/talk_service.rb#L86 and noticed `unrooted_params` has a `user_id`set to it and this impacts `permitted_params` aswell (my guess here is cos we're passing `permitted_params` directly from `unrooted_params` as opposed to a clone of it)

Making `unrooted_params` use a clone of `permitted_params` works fine but increases failing tests across and i added the `user_id` directly to the `:create_params` mentioned above, this works but not totally convinced. The 3rd solution is to build the service which is on the pr. What do you think?