### PR TITLE
Rails 5 - Fix NotificationMailer Specs

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -15,11 +15,11 @@ class NotificationMailer < ApplicationMailer
     find_notifications_for categories
     organize
 
-    mail to: @user.email, subject: subject(digest_frequency)
+    mail to: @user.email, subject: subject(digest_frequency), template_name: 'notify'
   end
 
   def find_categories_for(digest_frequency)
-    @user.subscription_preferences.enabled.where(email_digest: digest_frequency).pluck :category
+    @user.subscription_preferences.enabled.where(email_digest: digest_frequency).pluck(:category)
   end
 
   def find_notifications_for(categories)

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe NotificationMailer, type: :mailer do
 
   describe '#notify' do
     RSpec.shared_examples_for 'NotificationMailer#notify' do
-      let(:mailer){ NotificationMailer.send :new, :notify, user1, frequency }
       let(:frequency_int){ SubscriptionPreference.email_digests[frequency] }
       let(:mail){ mailer.notify user1, frequency }
 
@@ -100,22 +99,35 @@ RSpec.describe NotificationMailer, type: :mailer do
     before(:each){ mailer.instance_variable_set :@user, user1 }
     let(:categories){ mailer.find_categories_for SubscriptionPreference.email_digests[frequency] }
 
+    # TODO: Once on Rails 5, Can Remove Version Check.
+    # Rails 5 introduces a change to ActiveRecord:Enum where it typecasts enum attributes to its string value.
+    # See: https://github.com/rails/rails/commit/c51f9b61ce1e167f5f58f07441adcfa117694301
+    # Luckily we can still send int values when doing a where clause on categories AND by Rails 5, we can also do a string array search of categories. So we do not need to update `find_notifications_for`
+    # Regardless, we will test thoroughly in Staging Canary When Up.
+    # Version Checks are on L112, L120, L128
+
     context 'with immediate' do
       let(:frequency){ :immediate }
       subject{ categories }
-      it{ is_expected.to match_array Subscription.categories.values_at(:mentions, :group_mentions, :system, :moderation_reports) }
+      # TODO: When on Rails 5, Remove Version Checks (See L102 For Details)
+      expected_categories =  Rails.version.starts_with?('4.2') ? Subscription.categories.values_at(:mentions, :group_mentions, :system, :moderation_reports) : ['mentions', 'group_mentions', 'system', 'moderation_reports']
+      it{ is_expected.to match_array expected_categories }
     end
 
     context 'with daily' do
       let(:frequency){ :daily }
       subject{ categories }
-      it{ is_expected.to match_array Subscription.categories.values_at(:participating_discussions, :followed_discussions) }
+      # TODO: When on Rails 5, Remove Version Checks(See L102 For Details)
+      expected_categories =  Rails.version.starts_with?('4.2') ? Subscription.categories.values_at(:participating_discussions, :followed_discussions) : ['participating_discussions', 'followed_discussions']
+      it{ is_expected.to match_array expected_categories }
     end
 
     context 'with weekly' do
       let(:frequency){ :weekly }
       subject{ categories }
-      it{ is_expected.to match_array Subscription.categories.values_at(:messages, :started_discussions) }
+      # TODO: When on Rails 5, Remove Version Checks(See L102 For Details)
+      expected_categories =  Rails.version.starts_with?('4.2') ? Subscription.categories.values_at(:messages, :started_discussions) : ['messages', 'started_discussions']
+      it{ is_expected.to match_array expected_categories }
     end
 
     context 'with disabled preferences' do


### PR DESCRIPTION
Rails 5 - Fix NotificationMailer Specs

### **Changes**
-  Update `NotificationMailer#find_categories_for` specs to allow for Rails 5 typecasting of enum fields. 
        - **Rails 5 introduces a change to `ActiveRecord:Enum` where it typecasts enum attributes to its string value**. See: https://github.com/rails/rails/commit/c51f9b61ce1e167f5f58f07441adcfa117694301
        - Luckily we can still send int values when doing a where clause on categories AND by Rails 5, we can also do a string array search of categories. So we do not need to update `find_notifications_for`
          - **Decision Choice**: another option instead of version checks is to typecast the categories from `find_categories_for` back to its corresponding ints (eg. `.pluck('categories as i')`). IMO, this makes the `pluck` a bit harder to understand and as mentioned in previous bullet point, receiving categories as strings does not seem to have a breaking domino effect. (because `.where`  can accept either integer search or string search of enum fields). 
        -  Regardless, we will test thoroughly in Staging Canary When Up.

- Removed duplicate mailer method that uses `.send` in a  way that is which is no longer valid in Ruby 2.6+
- Add  `template_name` parameter to `mail to` to specify template used.  Due to a change in[ ActionMailer 4.2](https://github.com/rails/rails/blob/v4.2.11.3/actionmailer/lib/action_mailer/base.rb#L884-L907) -> [ Actionmailer 5.0](https://github.com/rails/rails/blob/5-0-stable/actionmailer/lib/action_mailer/base.rb#L897-L923)

### TODO Once On Staging

- [ ] Ensure NotificationMailer sends the correct template. (NotificationMailer used in NotificationEmailWorker which is enqueued via sidekiq-cron) 

