### PR TITLE
Rails 5.0 -- Fix comments_controller_spec.rb and moderations_controller_spec.rb

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -27,5 +27,6 @@ class CommentsController < ApplicationController
   def filter_subject_default
     board_ids = Board.where(section: params[:section], subject_default: params[:subject_default]).pluck :id
     params[:board_id] = board_ids.join ','
+    params.permit!
   end
 end

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -23,5 +23,6 @@ class ModerationsController < ApplicationController
     inverted_state = Moderation.states[params[:state]]
     raise Talk::InvalidParameterError.new(:state, "in #{ Moderation.states.keys }", params[:state]) unless inverted_state
     params[:state] = inverted_state
+    params.permit!
   end
 end

--- a/app/serializers/concerns/talk_serializer.rb
+++ b/app/serializers/concerns/talk_serializer.rb
@@ -66,7 +66,7 @@ module TalkSerializer
     end
 
     def page(params = { }, scope = nil, context = { })
-      super params, scope_preloading_for(scope), context.merge(params: params)
+      super params.to_h, scope_preloading_for(scope), context.merge(params: params)
     end
 
     def page_with_options(options)


### PR DESCRIPTION
**Changes**
- `permit` params and convert `to_h` because AC Params no longer inherits from `HashWithIndifferentAccess` https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#actioncontroller-parameters-no-longer-inherits-from-hashwithindifferentaccess. 
          -  Our fork/talk-version of restpack-serializer expects params to come in as a `Hash` (otherwise will return filters as `{}` when we do have filters in our params) See: https://github.com/zooniverse/restpack_serializer/blob/637aaaf85eda4f467c034f19f52e3f0cb6b20112/lib/restpack_serializer/options.rb#L58

This reminds me that as a future **TODO**: We need to update [our fork talk-api branch of restpack-serializer](https://github.com/zooniverse/restpack_serializer/tree/talk-api-version), similar to how we did panoptes. (I.e. update `protected_attributes` gem with `protected_attributes_continued` and update version constraints)
