### PR TITLE
rails-5.0-message-controller-spec

### DIFF
--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -19,6 +19,19 @@ class MessagePolicy < ApplicationPolicy
     false
   end
 
+  def participant?
+    return false unless logged_in?
+    Array.wrap(record).each do |r|
+      if r.persisted?
+        return r.users.exists?(id: user.id)
+      elsif r.conversation
+        return r.conversation.users.exists?(id: user.id)
+      end
+      return false
+    end
+    true
+  end
+
   class Scope < Scope
     def resolve
       scope.joins(:conversation, :user_conversations).where({


### PR DESCRIPTION
Issue is caused by how the exists? method called on the users association behaves in rails 4.2 and 5. 

Calling `r.users.exists?(id: user.id)` in rails 4 returns true even before persisting the record (and the array is actually empty at this point) while on 5 it is abit stricter and evaluates as false if the associations have not been properly formed since the record at that point has not been persisted (users array eventually has data after calling the `.save`). 

Workaround is  to check if persisted before checking in the users and if not, check on the conversations users instead.


NB: `participant?` is originally implemented on the base `ApplicationPolicy`, i am overriding in the `MessagePolicy` class as it is also used elsewhere