### PR TITLE
rails-5.0: fix issues with validation message in affected tests

### DIFF
--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe Message, type: :model do
 
     it 'should require a user' do
       without_user = build :message, user: nil, body: 'blah'
-      expect(without_user).to fail_validation user: "can't be blank"
+      expect(without_user).to fail_validation
     end
 
     it 'should require a conversation' do
       without_conversation = build :message, conversation: nil
-      expect(without_conversation).to fail_validation conversation: "can't be blank"
+      expect(without_conversation).to fail_validation
     end
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Notification, type: :model do
   context 'validating' do
     it 'should require a user' do
       without_target = build :notification, user: nil
-      expect(without_target).to fail_validation user: "can't be blank"
+      expect(without_target).to fail_validation
     end
 
     it 'should require a url' do
@@ -25,7 +25,7 @@ RSpec.describe Notification, type: :model do
 
     it 'should require a subscription' do
       without_subscription = build :notification, subscription: nil
-      expect(without_subscription).to fail_validation subscription: "can't be blank"
+      expect(without_subscription).to fail_validation
     end
   end
 

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Role, type: :model do
   context 'validating' do
     it 'should require a user' do
       without_user = build :role, user: nil
-      expect(without_user).to fail_validation user: "can't be blank"
+      expect(without_user).to fail_validation
     end
 
     it 'should prevent duplicates' do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Subscription, type: :model do
     it 'should require a user' do
       without_user = build :subscription, user: nil
       expect(without_user).to_not be_valid
-      expect(without_user).to fail_validation user: "can't be blank"
+      expect(without_user).to fail_validation
     end
 
     it 'should require a category' do
@@ -17,7 +17,7 @@ RSpec.describe Subscription, type: :model do
     it 'should require a source' do
       without_source = build :subscription, source: nil
       expect(without_source).to_not be_valid
-      expect(without_source).to fail_validation source: "can't be blank"
+      expect(without_source).to fail_validation
     end
 
     describe SubscriptionUniquenessValidator do


### PR DESCRIPTION
Fixes the validation messages across controllers that are affected. Issue and Fix is same with that on this [pr](https://github.com/zooniverse/talk-api/pull/327)