### PR TITLE
Revert "Rails 5.0 -- Fix comments_controller_spec.rb and moderations_controller_spec.rb"

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -27,6 +27,5 @@ class CommentsController < ApplicationController
   def filter_subject_default
     board_ids = Board.where(section: params[:section], subject_default: params[:subject_default]).pluck :id
     params[:board_id] = board_ids.join ','
-    params.permit!
   end
 end

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -23,6 +23,5 @@ class ModerationsController < ApplicationController
     inverted_state = Moderation.states[params[:state]]
     raise Talk::InvalidParameterError.new(:state, "in #{ Moderation.states.keys }", params[:state]) unless inverted_state
     params[:state] = inverted_state
-    params.permit!
   end
 end

--- a/app/serializers/concerns/talk_serializer.rb
+++ b/app/serializers/concerns/talk_serializer.rb
@@ -66,7 +66,7 @@ module TalkSerializer
     end
 
     def page(params = { }, scope = nil, context = { })
-      super params.to_h, scope_preloading_for(scope), context.merge(params: params)
+      super params, scope_preloading_for(scope), context.merge(params: params)
     end
 
     def page_with_options(options)


### PR DESCRIPTION
Reverts zooniverse/talk-api#330

This change introduces a bug when pulling boards from /boards?section=__ in Rails 4.2. reverting back and doing more investigation.