### PR TITLE
Rails 5 - update action_rendering#show to permit params and then convert to_h

### DIFF
--- a/app/controllers/concerns/action_rendering.rb
+++ b/app/controllers/concerns/action_rendering.rb
@@ -11,7 +11,8 @@ module ActionRendering
 
   def show
     authorize model_class.where(id: resource_ids)
-    render json: serializer_class.resource(params, nil, current_user: current_user)
+    params.permit!
+    render json: serializer_class.resource(params.to_h, nil, current_user: current_user)
   end
 
   def create


### PR DESCRIPTION
Bug found when testing notifications on Canary. /comments/<ID> pulls all the comments as opposed to the relevant comment