### PR TITLE
Rails 5 - fix Tags_Controller_Spec.rb

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -4,7 +4,8 @@ class TagsController < ApplicationController
 
   def popular
     params[:name].try :downcase!
-    render json: popular_serializer.resource(params, nil, current_user: current_user)
+    params.permit!
+    render json: popular_serializer.resource(params.to_h, nil, current_user: current_user)
   end
 
   def popular_serializer


### PR DESCRIPTION
update tags_controller#popular to permit params in order to convert to_h 
(Breaking behavior due to: in Rails 5 , ActionControllerParameters no longer inherits from HashWithIndifferentAccess)