### PR TITLE
Rails 5 - Fix discussion_spec.rb

### DIFF
--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Discussion, type: :model do
 
     it 'should require a user' do
       without_user = build :discussion, user_id: nil
-      expect(without_user).to fail_validation user: "can't be blank"
+      expect(without_user).to fail_validation
     end
 
     it 'should require a section' do
@@ -193,8 +193,18 @@ RSpec.describe Discussion, type: :model do
     let(:discussion){ create :discussion }
 
     it 'should queue the notification' do
-      expect(DiscussionSubscriptionWorker).to receive(:perform_async).with discussion.id
-      discussion.run_callbacks :commit
+      # TODO: Once on Rails 5, Can Remove this Version Check
+      # In Rails Versions < 5, commit callbacks are not getting called in transactional tests.
+      # See https://stackoverflow.com/a/30901628/15768801 for more details.
+      if Rails.version.starts_with?('5')
+        allow(DiscussionSubscriptionWorker).to receive(:perform_async)
+        discussion = build :discussion
+        discussion.save!
+        expect(DiscussionSubscriptionWorker).to have_received(:perform_async).with discussion.id
+      else
+        expect(DiscussionSubscriptionWorker).to receive(:perform_async).with discussion.id
+        discussion.run_callbacks :commit
+      end
     end
   end
 

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -190,8 +190,6 @@ RSpec.describe Discussion, type: :model do
   end
 
   describe '#notify_subscribers_later' do
-    let(:discussion){ create :discussion }
-
     it 'should queue the notification' do
       # TODO: Once on Rails 5, Can Remove this Version Check
       # In Rails Versions < 5, commit callbacks are not getting called in transactional tests.
@@ -202,6 +200,7 @@ RSpec.describe Discussion, type: :model do
         discussion.save!
         expect(DiscussionSubscriptionWorker).to have_received(:perform_async).with discussion.id
       else
+        discussion = create :discussion
         expect(DiscussionSubscriptionWorker).to receive(:perform_async).with discussion.id
         discussion.run_callbacks :commit
       end


### PR DESCRIPTION
**Changes**
- update validation message spec. it is enough for us to test that discussion fails validation because there is no user. no need to check for a rails error message that has changed from 4 -> 5
- after_commit callbacks do not run in transaction fixtures in specs for Rails 4, a workaround for Rails versions less than 5 is to use run_callbacks. Issue has been fixed in Rails 5. So we add a version check on spec. See https://stackoverflow.com/a/30901628/15768801 for more details.