### PR TITLE
Rails 5 - Fix users_controller_spec.rb

### DIFF
--- a/lib/username_completion.rb
+++ b/lib/username_completion.rb
@@ -21,7 +21,7 @@ class UsernameCompletion
   def query
     <<-SQL
       select
-        id::text,
+        id,
         login,
         display_name
 

--- a/lib/username_completion.rb
+++ b/lib/username_completion.rb
@@ -21,7 +21,7 @@ class UsernameCompletion
   def query
     <<-SQL
       select
-        id,
+        id::int,
         login,
         display_name
 

--- a/lib/username_completion.rb
+++ b/lib/username_completion.rb
@@ -21,7 +21,7 @@ class UsernameCompletion
   def query
     <<-SQL
       select
-        id::int,
+        id::text,
         login,
         display_name
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe UsersController, type: :controller do
 
       it 'should return the usernames' do
         expect(response.json[:usernames]).to match_array [{
-          'id' => user.id,
+          'id' => user.id.to_s,
           'login' => user.login,
           'display_name' => user.display_name
         }]

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe UsersController, type: :controller do
 
       it 'should return the usernames' do
         expect(response.json[:usernames]).to match_array [{
-          'id' => user.id.to_s,
+          'id' => user.id,
           'login' => user.login,
           'display_name' => user.display_name
         }]

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -49,8 +49,14 @@ RSpec.describe UsersController, type: :controller do
       it{ is_expected.to be_successful }
 
       it 'should return the usernames' do
+        # TODO: Remove version check once on Rails 5
+        # In Rails versions < 5, PG results when casted to_a,
+        # numeric types will get converted to string.
+        # After Rails 5, there is no typecasting, unless stated.
+        # See https://github.com/rails/rails/commit/c51f9b61ce1e167f5f58f07441adcfa117694301
+        expected_user_id = Rails.version.starts_with?('5') ? user.id : user.id.to_s
         expect(response.json[:usernames]).to match_array [{
-          'id' => user.id.to_s,
+          'id' => expected_user_id,
           'login' => user.login,
           'display_name' => user.display_name
         }]


### PR DESCRIPTION
**Changes**
- Added version check for user_id
- In Rails versions less than 5, PG::Results when converted to_a will cast numeric types to string. This gets fixed in Rails 5 (See https://github.com/rails/rails/commit/c51f9b61ce1e167f5f58f07441adcfa117694301 for more details)
      -  **Decision Choice**: Chose to do a version check instead of typecasting in SQL query (eg. `select id::int from etc`), which makes the query more readable in UsernameCompletion. 
