### PR TITLE
Rails 5 Upgrade - Update Staging to run on Rails 5 (building from Dockerfile.rails-next

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -12,7 +12,8 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/build_and_push_image.yaml@main
     with:
       repo_name: talk-api
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
+      file: Dockerfile.rails-next
       latest: true
 
   db_migration_staging:
@@ -22,7 +23,7 @@ jobs:
     with:
       app_name: talk-api
       environment: staging
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
     secrets:
       creds: ${{ secrets.AZURE_AKS }}
 
@@ -33,7 +34,7 @@ jobs:
     with:
       app_name: talk-api
       repo_name: talk-api
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
       environment: staging
     secrets:
       creds: ${{ secrets.AZURE_AKS }}

--- a/.github/workflows/deploy_staging_canary.yml
+++ b/.github/workflows/deploy_staging_canary.yml
@@ -2,9 +2,6 @@
 name: Deploy Staging Canary
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:

--- a/kubernetes/deployment-staging-canary.tmpl
+++ b/kubernetes/deployment-staging-canary.tmpl
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: talk-staging-canary-app
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: talk-staging-canary-app


### PR DESCRIPTION
- Set canary replicas to 0. 
- Build staging off of dockerfile.rails-next

Here is a similar PR on panoptes to give a bit more context on process (and can be used as a comparison for review) https://github.com/zooniverse/panoptes/pull/4111/files