### PR TITLE
Rails 5 - update enable_starttls_auto to true

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   config.active_record.raise_in_transactional_callbacks = true
 
   config.action_mailer.smtp_settings = {
-    enable_starttls_auto: ENV.fetch('MAILER_ENABLE_STARTTLS_AUTO', true),
+    enable_starttls_auto: true,
     address: ENV['MAILER_ADDRESS'],
     port: ENV.fetch('MAILER_PORT', 587).to_i,
     domain: ENV['MAILER_DOMAIN'] || 'zooniverse.org',

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   config.active_record.raise_in_transactional_callbacks = true
 
   config.action_mailer.smtp_settings = {
-    enable_starttls_auto: ENV.fetch('MAILER_ENABLE_STARTTLS_AUTO', true),
+    enable_starttls_auto: true,
     address: ENV['MAILER_ADDRESS'],
     port: ENV.fetch('MAILER_PORT', 587).to_i,
     domain: ENV['MAILER_DOMAIN'] || 'zooniverse.org',


### PR DESCRIPTION
- in Rails 4.2, the true value and false values are checked. In Rails 5, only false values are checked - unless the values is nil or matches a false value, it is assumed to be true.
- 'true' string no longer evaluates to true. default is true anyway so might as well set to true