### PR TITLE
Rails 5 - Enable Dependency Loading 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -58,6 +58,7 @@ module Talk
   end
 
   class Application < Rails::Application
+    config.enable_dependency_loading = true
     config.autoload_paths += [
       'lib',
       'app/schemas/concerns',


### PR DESCRIPTION
See: https://www.bigbinary.com/blog/rails-5-disables-autoloading-after-booting-the-app-in-production
One thing caught on Production: Autoloading is Disabled After Booting in the Production Environment. See Rails docs: https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#autoloading-is-disabled-after-booting-in-the-production-environment

Rails doc mentions that this change for the vast majority needs no action and we did not have to do anything similar in Panoptes. Unfortunately, this could only be caught in production. 


Since our app needs autoloading: we set `enable_dependency_loading` to true


See: Honeybadger https://app.honeybadger.io/projects/43180/faults/109666433