### PR TITLE
Fix talk data exports to exclude empty boards

### DIFF
--- a/app/workers/comment_export_worker.rb
+++ b/app/workers/comment_export_worker.rb
@@ -39,7 +39,7 @@ class CommentExportWorker
       from boards
       left join discussions on discussions.board_id = boards.id
       left join comments on comments.discussion_id = discussions.id
-      where boards.section = '#{ data_request.section }';
+      where boards.section = '#{ data_request.section }' and discussions.id is not null;
     SQL
   end
 

--- a/spec/workers/comment_export_worker_spec.rb
+++ b/spec/workers/comment_export_worker_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe CommentExportWorker, type: :worker do
     let(:data_request){ create :comments_data_request }
     let!(:comment1){ create :comment, section: data_request.section }
     let!(:comment2){ create :comment, section: data_request.section }
+    let!(:board_without_discussion) { create :board, section: data_request.section }
     let(:data){ subject.view_model.all.collect(&:to_json) }
     before(:each) do
       subject.data_request = data_request
@@ -54,6 +55,11 @@ RSpec.describe CommentExportWorker, type: :worker do
         format_of(comment1).to_json,
         format_of(comment2).to_json
       ]
+    end
+
+    it 'should not include empty boards' do
+      data_board_ids = subject.view_model.all.pluck(:board_id)
+      expect(data_board_ids).not_to include(board_without_discussion.id)
     end
   end
 


### PR DESCRIPTION
See Slack Thread Here: 
https://zooniverse.slack.com/archives/C06DCM0V9/p1720800370052409
Tech details of issue found here: https://zooniverse.slack.com/archives/C06DCM0V9/p1720800400003809?thread_ts=1720800370.052409&cid=C06DCM0V9

This PR fixes the issue: that Talk data_exports fail when there is an empty board (i.e. a board without discussion or comment). 

**Change:**
Ensure the sql view created does not include empty boards so that when querying comment exports view, we ensure that each comment has a comment id (primary key of the sql view created).