### PR TITLE
Rails 5 deprecation warnings on config attributes

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,6 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
   config.active_support.deprecation = :log
   config.active_record.migration_error = :page_load
-  config.active_record.raise_in_transactional_callbacks = true
   # Don't care if the mailer can't send emails in dev
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
   config.action_controller.allow_forgery_protection = false
-  config.serve_static_files = false
+  config.public_file_server.enabled = false
   config.force_ssl = true
   config.log_level = :info
   config.i18n.fallbacks = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,7 +12,6 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
   config.log_formatter = ::Logger::Formatter.new
   config.active_record.dump_schema_after_migration = false
-  config.active_record.raise_in_transactional_callbacks = true
 
   config.action_mailer.smtp_settings = {
     enable_starttls_auto: true,

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
   config.action_controller.allow_forgery_protection = false
-  config.serve_static_files = false
+  config.public_file_server.enabled = false
   config.force_ssl = !ENV['VAGRANT_APP']
   config.log_level = :info
   config.i18n.fallbacks = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -12,7 +12,6 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
   config.log_formatter = ::Logger::Formatter.new
   config.active_record.dump_schema_after_migration = false
-  config.active_record.raise_in_transactional_callbacks = true
 
   config.action_mailer.smtp_settings = {
     enable_starttls_auto: true,

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -3,13 +3,12 @@ Rails.application.configure do
   config.cache_store = :null_store
   config.eager_load = false
   config.public_file_server.enabled = true
-  config.static_cache_control = 'public, max-age=3600'
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.action_controller.allow_forgery_protection = false
   config.action_dispatch.show_exceptions = false
   config.active_support.deprecation = :stderr
-  config.active_record.raise_in_transactional_callbacks = true
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = {
     protocol: 'http',

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -2,7 +2,7 @@ Rails.application.configure do
   config.cache_classes = true
   config.cache_store = :null_store
   config.eager_load = false
-  config.serve_static_files = true
+  config.public_file_server.enabled = true
   config.static_cache_control = 'public, max-age=3600'
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false


### PR DESCRIPTION
- update deprecated `config.serve_static_files` with `config.public_file_server.enabled`
- update deprecated `config.static_cache_control` to `config.public_file_server.headers`
-  remove deprecated `raise_in_transactional_callbacks` 
           - Change transaction callbacks to not swallow errors. Before this change any errors raised inside a transaction callback were getting rescued and printed in the logs, unless you used the (newly deprecated) `raise_in_transactional_callbacks = true` option. (See: https://edgeguides.rubyonrails.org/5_0_release_notes.html)

