### PR TITLE
Rails 5 -  deprecated style on shared controller specs 

### DIFF
--- a/spec/support/shared_examples_for_controller_actions.rb
+++ b/spec/support/shared_examples_for_controller_actions.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.shared_examples_for 'a controller action' do
-  let(:send_request){ send verb, action, params.merge(format: :json) }
+  let(:send_request){ send verb, action, params: params.merge(format: :json) }
 
   it 'should authorize the action' do
     if authorizable

--- a/spec/support/shared_examples_for_controller_creating.rb
+++ b/spec/support/shared_examples_for_controller_creating.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples_for 'a controller creating' do
   end
 
   describe '#create' do
-    let(:send_request){ post :create, request_params.merge(format: :json) }
+    let(:send_request){ post :create, params:  request_params.merge(format: :json) }
 
     it 'should authorize the action' do
       expect_any_instance_of(subject.service_class).to receive :authorize

--- a/spec/support/shared_examples_for_controller_rendering.rb
+++ b/spec/support/shared_examples_for_controller_rendering.rb
@@ -36,7 +36,7 @@ RSpec.shared_examples_for 'a controller rendering' do |*actions|
 
       it 'should serialize the resource' do
         expect(subject.serializer_class).to receive(:resource).and_call_original
-        get :show, id: record.id
+        get :show, params: { id: record.id }
       end
     end
   end

--- a/spec/support/shared_examples_for_controller_updating.rb
+++ b/spec/support/shared_examples_for_controller_updating.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples_for 'a controller updating' do
   end
 
   describe '#update' do
-    let(:send_request){ put :update, request_params.merge(format: :json) }
+    let(:send_request){ put :update, params: request_params.merge(format: :json) }
 
     it 'should authorize the action' do
       expect_any_instance_of(subject.service_class).to receive :authorize


### PR DESCRIPTION
Rails 5 - DEPRECATION WARNING Using positional arguments in functional tests has been deprecated in favor of keyword arguments, and will be removed in Rails 5.1.

- add key `params` when declaring params for request in specs (there will be followup PRs of similar nature for other specs, this PR addresses the deprecated style in shared controller specs) 