### PR TITLE
Rails 5 - update deprecated style (using positional arguments in functional tests) in controller [a-m] specs.  

### DIFF
--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CommentsController, type: :controller do
       let(:href_params){ CGI.parse URI.parse(first_href).query }
 
       context 'when false' do
-        before(:each){ get :index, format: :json, section: 'project-1', subject_default: false }
+        before(:each){ get :index, format: :json, params: { section: 'project-1', subject_default: false } }
 
         it 'should filter comments from subject default boards' do
           expect(response_ids).to match_array comment_ids
@@ -40,7 +40,7 @@ RSpec.describe CommentsController, type: :controller do
       end
 
       context 'when true' do
-        before(:each){ get :index, format: :json, section: 'project-1', subject_default: true }
+        before(:each){ get :index, params: { format: :json, section: 'project-1', subject_default: true } }
 
         it 'should filter comments from subject default boards' do
           expect(response_ids).to match_array [subject_default_comment.id.to_s]
@@ -86,7 +86,7 @@ RSpec.describe CommentsController, type: :controller do
       end
 
       it 'should set the user ip' do
-        post :create, request_params.merge(format: :json)
+        post :create, params: request_params.merge(format: :json)
         id = response.json['comments'].first['id']
         comment = Comment.find id
         expect(comment.user_ip).to eql request.remote_ip
@@ -109,7 +109,7 @@ RSpec.describe CommentsController, type: :controller do
   context 'with a non-author user' do
     let(:record){ create :comment }
     let(:user){ create :user }
-    let(:send_request){ put upvote_method, id: record.id.to_s, format: :json }
+    let(:send_request){ put upvote_method, params: { id: record.id.to_s, format: :json }}
     before(:each){ allow(subject).to receive(:current_user).and_return user }
 
     it_behaves_like 'a controller restricting',

--- a/spec/controllers/conversations_controller_spec.rb
+++ b/spec/controllers/conversations_controller_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe ConversationsController, type: :controller do
       end
 
       it 'should have the correct participant ids' do
-        post :create, request_params.merge(format: :json)
+        post :create, params: request_params.merge(format: :json)
         conversation = Conversation.first
         user_ids = [current_user.id] + recipients.map(&:id)
         expect(conversation.participant_ids).to match_array user_ids
       end
 
       it 'should set the user ip' do
-        post :create, request_params.merge(format: :json)
+        post :create, params: request_params.merge(format: :json)
         conversation_id = response.json['conversations'].first['id']
         message = Message.where(conversation_id: conversation_id).first
         expect(message.user_ip).to eql request.remote_ip
@@ -64,7 +64,7 @@ RSpec.describe ConversationsController, type: :controller do
       let!(:record){ create :conversation_with_messages, user: user }
 
       def destroy_conversation
-        delete :destroy, id: record.id, format: :json
+        delete :destroy, params: { id: record.id, format: :json }
       end
 
       it 'should set the status' do
@@ -110,7 +110,7 @@ RSpec.describe ConversationsController, type: :controller do
       let(:record){ create :conversation_with_messages }
       let(:recipient){ record.user_conversations.where(is_unread: true).first.user }
       let(:sender){ record.user_conversations.where(is_unread: false ).first.user }
-      let(:json){ get(:index, unread: true); response.json['conversations'] }
+      let(:json){ get(:index, params: { unread: true }); response.json['conversations'] }
 
       before(:each) do
         allow(subject).to receive(:current_user).and_return current_user
@@ -146,7 +146,7 @@ RSpec.describe ConversationsController, type: :controller do
 
       it 'should mark the conversation as read' do
         expect(Conversation).to receive(:mark_as_read_by).with [record.id], recipient.id
-        get :show, id: record.id.to_s
+        get :show, params: { id: record.id.to_s }
       end
     end
   end

--- a/spec/controllers/discussions_controller_spec.rb
+++ b/spec/controllers/discussions_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe DiscussionsController, type: :controller do
       end
 
       it 'should set the user ip' do
-        post :create, request_params.merge(format: :json)
+        post :create, params: request_params.merge(format: :json)
         discussion_id = response.json['discussions'].first['id']
         comment = Comment.where(discussion_id: discussion_id).first
         expect(comment.user_ip).to eql request.remote_ip

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe MessagesController, type: :controller do
       end
 
       it 'should set the user ip' do
-        post :create, request_params.merge(format: :json)
+        post :create, params: request_params.merge(format: :json)
         id = response.json['messages'].first['id']
         message = Message.find id
         expect(message.user_ip).to eql request.remote_ip

--- a/spec/controllers/moderations_controller_spec.rb
+++ b/spec/controllers/moderations_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ModerationsController, type: :controller do
       before(:each) do
         create :moderation, :closed
         create :moderation, :watched
-        get :index, state: state, format: :json
+        get :index, params: { state: state, format: :json }
       end
 
       context 'with a valid state' do
@@ -84,7 +84,7 @@ RSpec.describe ModerationsController, type: :controller do
     context 'when the target is already reported' do
       before(:each) do
         create :reported_comment, target: target, message: 'first', user: first_user
-        post :create, request_params.merge(format: :json)
+        post :create, params: request_params.merge(format: :json)
       end
 
       let(:first_user){ create :user }


### PR DESCRIPTION
 update deprecated style in controller specs. 
Rails 5 - DEPRECATION WARNING Using positional arguments in functional tests has been deprecated in favor of keyword arguments, and will be removed in Rails 5.1.


- add key `params` when declaring params for request in controller specs a-m