### PR TITLE
Rails 5 - update deprecated style using positional arguments in functional tests in controller [n-z] specs.

### DIFF
--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe NotificationsController, type: :controller do
       let!(:notifications){ create_list :notification, 2 }
 
       it 'should scope updates to the user' do
-        put :read, { format: :json, id: notifications.map(&:id).join(',') }
+        put :read, params: { format: :json, id: notifications.map(&:id).join(',') }
         statuses = notifications.map{ |notification| notification.reload.delivered }
         expect(statuses).to all be false
       end
@@ -68,18 +68,18 @@ RSpec.describe NotificationsController, type: :controller do
       let!(:others){ create_list :notification, 2, section: 'project-1' }
 
       it 'should scope updates to the user with specified ids' do
-        put :read, { format: :json, id: ([record, record2] + others).map(&:id).join(',') }
+        put :read, params: { format: :json, id: ([record, record2] + others).map(&:id).join(',') }
         owned_statuses = [record, record2].map{ |notification| notification.reload.delivered }
         expect(owned_statuses).to all be true
       end
 
       it 'should not update unspecified notifications with specified ids' do
-        put :read, { format: :json, id: ([record, record2] + others).map(&:id).join(',') }
+        put :read, params: { format: :json, id: ([record, record2] + others).map(&:id).join(',') }
         expect(record3.reload).to_not be_delivered
       end
 
       it 'should scope updates to the user with specified ids' do
-        put :read, { format: :json, id: ([record, record2] + others).map(&:id).join(',') }
+        put :read, params: { format: :json, id: ([record, record2] + others).map(&:id).join(',') }
         other_statuses = others.map{ |notification| notification.reload.delivered }
         expect(other_statuses).to all be false
       end
@@ -97,18 +97,18 @@ RSpec.describe NotificationsController, type: :controller do
       end
 
       it 'should scope updates to the user with the specified section' do
-        put :read, { format: :json, section: 'project-1' }
+        put :read, params: { format: :json, section: 'project-1' }
         section_statuses = [record, record2].map{ |notification| notification.reload.delivered }
         expect(section_statuses).to all be true
       end
 
       it 'should not update other sections for the user' do
-        put :read, { format: :json, section: 'project-1' }
+        put :read, params: { format: :json, section: 'project-1' }
         expect(record3.reload).to_not be_delivered
       end
 
       it 'should not update for other users in the section' do
-        put :read, { format: :json, section: 'project-1' }
+        put :read, params: { format: :json, section: 'project-1' }
         expect(others.map(&:reload).map(&:delivered)).to all be false
       end
     end

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe SearchesController, type: :controller do
-  let(:send_request){ get :index, request_params.merge(format: :json) }
+  let(:send_request){ get :index, params: request_params.merge(format: :json) }
 
   describe '#index' do
     context 'without a section param' do

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe TagsController, type: :controller do
         if serializer
           allow(serializer).to receive(:resource).and_call_original
         end
-        get :popular, params
+        get :popular, params: params
       end
 
       it 'should use the correct serializer' do
@@ -129,7 +129,7 @@ RSpec.describe TagsController, type: :controller do
     let!(:tag){ create :tag, name: 'foo' }
     let(:params){ { } }
     subject{ response }
-    before(:each){ get :autocomplete, params }
+    before(:each){ get :autocomplete, params: params }
 
     context 'without a search' do
       let(:params){ { search: 'f' } }
@@ -153,7 +153,7 @@ RSpec.describe TagsController, type: :controller do
         completer = double results: []
         expect(TagCompletion).to receive(:new).with('f', 'project-1', limit: 5).and_return completer
         expect(completer).to receive :results
-        get :autocomplete, params
+        get :autocomplete, params: params
       end
     end
   end

--- a/spec/controllers/unsubscribe_controller_spec.rb
+++ b/spec/controllers/unsubscribe_controller_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe UnsubscribeController, type: :controller do
 
     context 'with a valid token' do
       it 'should render' do
-        get :index, token: valid_token
+        get :index, params: { token: valid_token }
         expect(response).to be_ok
       end
 
       it 'should log the event' do
         expect(EventLog).to receive(:create).with label: 'unsubscribe', user_id: user.id, payload: { ip: String }
-        get :index, token: valid_token
+        get :index, params: { token: valid_token }
       end
 
       it 'should unsubscribe the user' do
-        get :index, token: valid_token
+        get :index, params: { token: valid_token }
         digests = user.subscription_preferences.map &:email_digest
         expect(digests).to all eql 'never'
       end
@@ -25,13 +25,13 @@ RSpec.describe UnsubscribeController, type: :controller do
 
     context 'without a valid token' do
       it 'should render' do
-        get :index, token: 'nope'
+        get :index, params: { token: 'nope' }
         expect(response).to be_ok
       end
 
       it 'should log the event' do
         expect(EventLog).to receive(:create).with label: 'unsubscribe', user_id: nil, payload: { ip: String }
-        get :index, token: 'nope'
+        get :index, params: { token: 'nope' }
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe UsersController, type: :controller do
 
     before(:each) do
       allow(controller).to receive(:current_user).and_return current_user
-      get :autocomplete, params
+      get :autocomplete, params: params
     end
 
     context 'without an authorized user' do
@@ -61,7 +61,7 @@ RSpec.describe UsersController, type: :controller do
         completer = double results: []
         expect(UsernameCompletion).to receive(:new).with(current_user, 'f', limit: 5).and_return completer
         expect(completer).to receive :results
-        get :autocomplete, params
+        get :autocomplete, params: params
       end
     end
   end


### PR DESCRIPTION
update deprecated style in controller specs.
Rails 5 - DEPRECATION WARNING Using positional arguments in functional tests has been deprecated in favor of keyword arguments, and will be removed in Rails 5.1.

- add key `params` when declaring params for request in controller specs n-z