### PR TITLE
Rails 5 - Update searches_controller search_href to use permitted params and then convert to hash because params no longer inherits from HashWithIndifferentAccess

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -49,7 +49,7 @@ class SearchesController < ApplicationController
   end
 
   def search_href(opts = { })
-    permitted = params.slice :page, :page_size, :section, :query, :types
+    permitted = permit_params.to_h.slice :page, :page_size, :section, :query, :types
     query_opts = permitted.merge(opts).collect{ |k, v| "#{ k }=#{ v }" }.join '&'
     "/searches?#{ query_opts }"
   end


### PR DESCRIPTION
update search_href to use permitted params and then call to_h… because params no longer inherit from HashWithIndifferentAccess

See: https://github.com/rails/rails/pull/20868 and https://www.bigbinary.com/blog/parameters-no-longer-inherit-from-hash-with-indifferent-access-in-rails-5 for more details