### PR TITLE
Rails 5 - replace deprecated .uniq with .distinct in project_policy.rb

### DIFF
--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -20,7 +20,7 @@ class ProjectPolicy < ApplicationPolicy
         .where('private is not true')
         .joins(:boards)
         .order(launched_row_order: :desc)
-        .uniq
+        .distinct
     end
   end
 end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ProjectPolicy, type: :policy do
   context 'with scope' do
     let!(:launched1){ create :project, launched_row_order: 1 }
     let!(:board1){ create :board, section: "project-#{ launched1.id }" }
+    let!(:second_board_of_launched1){ create :board, section: "project-#{ launched1.id }" }
 
     let!(:launched2){ create :project, launched_row_order: 2 }
     let!(:board2){ create :board, section: "project-#{ launched2.id }" }


### PR DESCRIPTION
- replace deprecated `.uniq` with `.distinct` in project_policy.rb
- update test with secondary board of launched project to ensure distinct projects on query result