### PR TITLE
Rails 5 - Update subscription.rb to throw abort on callback chain when false is returned

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :test, :development do
   gem 'guard-rspec'
   gem 'pry'
   gem 'rspec-its'
-  gem 'rspec-rails'
+  gem 'rspec-rails', '~> 4.1.2'
   gem 'spring-commands-rspec'
   gem 'ten_years_rails'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,7 +389,7 @@ DEPENDENCIES
   redis (~> 3.3.0)
   restpack_serializer!
   rspec-its
-  rspec-rails
+  rspec-rails (~> 4.1.2)
   schema_plus_pg_indexes
   sidekiq (< 6)
   sidekiq-congestion (~> 0.1.0)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -389,7 +389,7 @@ DEPENDENCIES
   redis (~> 3.3.0)
   restpack_serializer!
   rspec-its
-  rspec-rails
+  rspec-rails (~> 4.1.2)
   schema_plus_pg_indexes
   sidekiq (< 6)
   sidekiq-congestion (~> 0.1.0)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -17,7 +17,7 @@ class Subscription < ApplicationRecord
   end
 
   def ensure_enabled
-    preference.enabled?
+    throw(:abort) unless preference.enabled?
   end
 
   def enabled?


### PR DESCRIPTION
Rails 5 deprecated behavior. Update subscription.rb to throw abort on callback chain when false is returned. 

See: https://www.bigbinary.com/blog/rails-5-does-not-halt-callback-chain-when-false-is-returned and following deprecation warning on rails 5

```
DEPRECATION WARNING: Returning `false` in Active Record and Active Model callbacks will not implicitly halt a callback chain in Rails 5.1. To explicitly halt the callback chain, please use `throw :abort` instead. (called from block (4 levels) in <top (required)> at /home/runner/work/talk-api/talk-api/spec/models/subscription_spec.rb:70)
```


Also adding version constraints on rspec-rails. rspec-rails 5.0 not compatible with rails <= 5.1 but will be compatible with rails 5.2, see https://github.com/rspec/rspec-rails/blob/v5.0.0/Changelog.md#500--2021-03-09