### PR TITLE
Rails 5 - Deprecated behavior - Passing an arg to force association to reload is deprecated. Call reload instead on message_spec.rb

### DIFF
--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Message, type: :model do
         expect {
           create :message, conversation: conversation, user: destroyed_conversation.user
         }.to change {
-          conversation.user_conversations(true).where(user: destroyed_conversation.user).exists?
+          conversation.user_conversations.reload.where(user: destroyed_conversation.user).exists?
         }.from(false).to true
       end
     end


### PR DESCRIPTION
Rails 5 - Deprecated behavior - Passing an arg to force association to reload is deprecated. Call reload instead on message_spec.rb

See deprecation warning:
`
DEPRECATION WARNING: Passing an argument to force an association to reload is now deprecated and will be removed in Rails 5.1. Please call `reload` on the result collection proxy instead. (called from block (5 levels) in <top (required)> at /home/runner/work/talk-api/talk-api/spec/models/message_spec.rb:68)
`