### PR TITLE
FactoryBot Deprecated behavior -- static attributes will be removed in favor of dynamic attributes

### DIFF
--- a/spec/factories/conversations.rb
+++ b/spec/factories/conversations.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
 
     factory :conversation_with_messages do
       transient do
-        user nil
-        recipients nil
+        user { nil }
+        recipients { nil }
         message_count { 2 }
       end
 

--- a/spec/factories/moderations.rb
+++ b/spec/factories/moderations.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     factory :reported_comment do
       transient do
         message { 'reported' }
-        user nil
+        user { nil }
       end
 
       before :create do |moderation, evaluator|

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence :id
     display_name { "Project #{ id }" }
     slug{ "#{ create(:user).login.parameterize }/#{ display_name.parameterize }" }
-    private nil
+    private { nil }
     launch_approved { true }
     sequence :launched_row_order
   end


### PR DESCRIPTION
Deprecated behavior for factory bot. Static Attributes will be removed in favor of dynamic attributes. Wrapping attributes value in a block to use dynamic attributes

See deprecation warning
`DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic attributes instead by wrapping the attribute value in a block`