### PR TITLE
Rails 5.1 test fixes - Stubbing adapter method and model methods for mocked objects

### DIFF
--- a/spec/support/shared_examples_for_data_export_worker.rb
+++ b/spec/support/shared_examples_for_data_export_worker.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.shared_examples_for 'a data export worker' do
-  it{ is_expected.to be_a Sidekiq::Worker }
+  it { is_expected.to be_a Sidekiq::Worker }
   let!(:data_request){ create :data_request }
 
   describe '#compress' do
@@ -172,6 +172,9 @@ RSpec.shared_examples_for 'a data export worker' do
 
     before(:each) do
       allow(DataRequest).to receive(:find).with(data_request.id).and_return data_request
+      allow_any_instance_of(DataRequest).to receive(:started!)
+      allow_any_instance_of(DataRequest).to receive(:finished!)
+      allow_any_instance_of(DataRequest).to receive(:failed!)
       allow(subject).to receive :process_data
       allow(Time).to receive_message_chain('now.utc.to_date.to_s'){ '2015-07-21' }
     end
@@ -203,6 +206,9 @@ RSpec.shared_examples_for 'a data export worker' do
 
     it 'should indicate failure' do
       allow(subject).to receive(:process_data).and_raise 'hell'
+      data_request.state = 'failed'
+      allow_any_instance_of(DataRequest).to receive(:failed!).and_return(data_request)
+
 
       expect{
         subject.perform data_request.id

--- a/spec/workers/comment_export_worker_spec.rb
+++ b/spec/workers/comment_export_worker_spec.rb
@@ -1,7 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe CommentExportWorker, type: :worker do
-  it_behaves_like 'a data export worker'
+  describe 'a data export worker' do
+    before(:each) do
+      allow_any_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter).to receive(:query)
+    end
+
+    it_behaves_like 'a data export worker'
+  end
 
   def format_of(comment)
     {


### PR DESCRIPTION
See eg failing spec result: 
`TagExportWorker behaves like a data export worker #perform should set the data request started
     Failure/Error: data_request.finished!
       #<Double (anonymous)> received unexpected message :- with (#<Double (anonymous)>)`

This happens because the mocked data_request does not recognize the model's enum method `finished!`, we therefore have to allow the test double to receive the enum method . 