### PR TITLE
Rails 5.1 - Build Staging with Dockerfile-next 

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -12,7 +12,8 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/build_and_push_image.yaml@main
     with:
       repo_name: talk-api
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
+      file: Dockerfile.rails-next
       latest: true
 
   db_migration_staging:
@@ -22,7 +23,7 @@ jobs:
     with:
       app_name: talk-api
       environment: staging
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
     secrets:
       creds: ${{ secrets.AZURE_AKS }}
 
@@ -33,7 +34,7 @@ jobs:
     with:
       app_name: talk-api
       repo_name: talk-api
-      commit_id: ${{ github.sha }}
+      commit_id: ${{ github.sha }}-next
       environment: staging
     secrets:
       creds: ${{ secrets.AZURE_AKS }}

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :test, :development do
   gem 'guard-rspec'
   gem 'pry'
   gem 'rspec-its'
-  gem 'rspec-rails', '~> 4.1.2'
+  gem 'rspec-rails', '~> 4.1.2' # upgrade when on rails 5.2
   gem 'spring-commands-rspec'
   gem 'ten_years_rails'
   gem 'timecop'

--- a/kubernetes/deployment-staging-canary.tmpl
+++ b/kubernetes/deployment-staging-canary.tmpl
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: talk-staging-canary-app
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: talk-staging-canary-app


### PR DESCRIPTION
- update deploy_staging to use dockerfile-next commits 
- update canary replicas to 0.
- add TODO comment on gemfile as reminder of when to update a rspec-rails gem

TODO need to run deploy staging canary GH action in order to get this change to apply to staging canary