### PR TITLE
Rails 5.1 Deprecation Warning - update discussion replacing deprecated attr_changed? with save_change_to_attr? and

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -25,7 +25,7 @@ class Discussion < ApplicationRecord
   before_create :denormalize_attributes
   before_save :clear_sticky, unless: ->{ sticky? }
   before_save :set_sticky_position, if: ->{ sticky? && sticky_position.nil? }
-  after_update :update_board_counters, if: ->{ board_id_changed? }
+  after_update :update_board_counters, if: ->{ saved_change_to_board_id? }
 
   moderatable_with :destroy, by: [:moderator, :admin]
   moderatable_with :ignore, by: [:moderator, :admin]
@@ -70,7 +70,7 @@ class Discussion < ApplicationRecord
 
   def update_board_counters
     comments.update_all board_id: board_id
-    changes.fetch(:board_id, []).compact.each do |id|
+    saved_changes.fetch(:board_id, []).compact.each do |id|
       Board.find_by_id(id).try :count_users_and_comments!
     end
   end


### PR DESCRIPTION
Rails 5.1 Deprecation Warning - update discussion replacing deprecated attr_changed? with save_change_to_attr? and

See: 
https://www.fastruby.io/blog/rails/upgrades/active-record-5-1-api-changes.html
or 
https://docspring.com/blog/posts/rails-5-1-active-model-dirty-changes/
