### PR TITLE
increase memory limits for sidekiq pods

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -215,10 +215,10 @@ spec:
           image: ghcr.io/zooniverse/talk-api:__IMAGE_TAG__
           resources:
             requests:
-              memory: "250Mi"
+              memory: "500Mi"
               cpu: "250m"
             limits:
-              memory: "700Mi"
+              memory: "1500Mi"
               cpu: "1000m"
           livenessProbe:
             exec:


### PR DESCRIPTION
TagExportWorker/CommentExportWorker for  are failing sometimes with OOM errors and more often silently. 

This could be due to our version of sidekiq (known issue on sidekiq 5, mentioned on this Slack thread: https://zooniverse.slack.com/archives/C06DCM0V9/p1722549690747489?thread_ts=1722258004.757699&cid=C06DCM0V9) 

Until  get our Rails and Ruby upgrades in (and subsequently Sidekiq) which will take some time, we will do this increase memory resources of talk sidekiq pod in the meantime. 