### PR TITLE
Rails 5.2 specs - Remove calling run_callbacks commit spec workarounds

### DIFF
--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Announcement, type: :model do
   end
 
   context 'creating' do
-    let(:announcement){ create :announcement }
     it 'should publish' do
+      announcement = create :announcement
       expect(AnnouncementWorker).to receive :perform_async
       announcement.run_callbacks :commit
     end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe Announcement, type: :model do
   end
 
   context 'creating' do
+    let(:announcement){ build :announcement }
     it 'should publish' do
       announcement = create :announcement
       expect(AnnouncementWorker).to receive :perform_async
-      announcement.run_callbacks :commit
+      announcement.save!
     end
   end
 

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Announcement, type: :model do
   context 'creating' do
     let(:announcement){ build :announcement }
     it 'should publish' do
-      announcement = create :announcement
       expect(AnnouncementWorker).to receive :perform_async
       announcement.save!
     end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -30,10 +30,11 @@ RSpec.describe Notification, type: :model do
   end
 
   context 'creating' do
+    let(:notification){ build :notification }
     it 'should publish' do
       notification = create :notification
       expect(NotificationWorker).to receive :perform_async
-      notification.run_callbacks :commit
+      notification.save!
     end
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Notification, type: :model do
   context 'creating' do
     let(:notification){ build :notification }
     it 'should publish' do
-      notification = create :notification
       expect(NotificationWorker).to receive :perform_async
       notification.save!
     end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Notification, type: :model do
   end
 
   context 'creating' do
-    let(:notification){ create :notification }
     it 'should publish' do
+      notification = create :notification
       expect(NotificationWorker).to receive :perform_async
       notification.run_callbacks :commit
     end


### PR DESCRIPTION
See: https://stackoverflow.com/a/30901628/15768801

In Rails versions < 5, in order to test after_commit callbacks, one would have to actually run the commit callback via `run_callbacks`. This issue gets fixed in Rails 5+.  