### PR TITLE
Update user_serializer to serialize valid_email and confirmed_at

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -3,7 +3,7 @@ class UserSerializer
   include ModerationActions
 
   attributes :id, :created_at, :updated_at, :login, :display_name,
-    :zooniverse_id, :credited_name, :admin, :banned
+    :zooniverse_id, :credited_name, :admin, :banned, :valid_email, :confirmed_at
 
   def href
     nil


### PR DESCRIPTION
Update user_serializer to serialize valid_email and confirmed_at

Noticed in Rails 5.2, because of change in schema load, table exists in 5.2 but not in 5.1, if we want to expose all attributes of user fdw (except for email). we should also be serializing the new `valid_email` and `confirmed_at` attributes created with email verification for talk