### PR TITLE
Update bundler to v2 for dual boot, Update Dual Boot to run ruby 2.7

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -29,6 +29,12 @@ jobs:
           - Gemfile.next
         ruby:
           - 2.6
+          - 2.7
+        exclude:
+          - gemfile: Gemfile
+            ruby: 2.7
+          - gemfile: Gemfile.next
+            ruby: 2.6
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
 

--- a/Dockerfile.rails-next
+++ b/Dockerfile.rails-next
@@ -1,4 +1,4 @@
-FROM ruby:2.6-slim-buster
+FROM ruby:2.7-slim-buster
 
 WORKDIR /rails_app
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,4 +409,4 @@ DEPENDENCIES
   zoo_stream (~> 1.0)
 
 BUNDLED WITH
-   1.17.3
+   2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,4 +409,4 @@ DEPENDENCIES
   zoo_stream (~> 1.0)
 
 BUNDLED WITH
-   2.4.22
+   1.17.3

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -388,4 +388,4 @@ DEPENDENCIES
   zoo_stream (~> 1.0)
 
 BUNDLED WITH
-   1.17.2
+   2.4.22


### PR DESCRIPTION
### Changes
- Update bundler to V2  on dual boot
- Dual boot running on Ruby 2.7

### TODO: 
A lot of specs are failing in 2.7 due to removal of `new_ostruct_member` https://github.com/ruby/ruby/pull/2178/files
         - This method is used in parrish's json-schema_builder (which I just created a fork of) since his version has not been maintained since 2018.  So TODO is the following

- [ ] Update talk to use our forked version of json-schema_builder (Note that forked version is probably several commits different than current talk version since current talk version uses v0.0.8 and forked version's master is closest to latest tag which is v0.8.2)
- [ ] Update json-schema_builder so it's compatible with Ruby 2.7+
         

