### PR TITLE
Rails 6.1 - Replace deprecated update_attributes with update in  specs (data_request, message, subscription) 

### DIFF
--- a/spec/models/data_request_spec.rb
+++ b/spec/models/data_request_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe DataRequest, type: :model do
     let(:data_request){ create :data_request, user: user }
 
     before :each do
-      unsubscribed_user.preference_for(:system).update_attributes enabled: false
+      unsubscribed_user.preference_for(:system).update enabled: false
     end
 
     context 'with a subscribed user' do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Message, type: :model do
     context 'when preference is disabled' do
       context 'for the sender' do
         before(:each) do
-          user.preference_for(:messages).update_attributes enabled: false
+          user.preference_for(:messages).update enabled: false
         end
         include_context 'existing conversation'
 
@@ -112,7 +112,7 @@ RSpec.describe Message, type: :model do
       context 'for the recipient' do
         before(:each) do
           recipients.each do |recipient|
-            recipient.preference_for(:messages).update_attributes enabled: false
+            recipient.preference_for(:messages).update enabled: false
           end
         end
         include_context 'existing conversation'
@@ -130,7 +130,7 @@ RSpec.describe Message, type: :model do
 
   describe '#notify_subscribers' do
     before(:each) do
-      user.preference_for(:messages).update_attributes enabled: false
+      user.preference_for(:messages).update enabled: false
     end
     include_context 'existing conversation'
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Subscription, type: :model do
       let!(:subscription){ create :subscription }
       it 'should clear notifications' do
         expect{
-          subscription.update_attributes enabled: false
+          subscription.update enabled: false
         }.to change{
           Notification.count
         }.from(3).to 1
@@ -92,7 +92,7 @@ RSpec.describe Subscription, type: :model do
       let!(:subscription){ create :subscription, enabled: false }
       it 'should not clear notifications' do
         expect{
-          subscription.update_attributes enabled: true
+          subscription.update enabled: true
         }.to_not change{
           Notification.count
         }


### PR DESCRIPTION
Rails 6.1 - Replace deprecated update_attributes with update in  data_request_spec.rb , message_spec.rb, subscription_spec.rb
See: https://blog.saeloun.com/2019/04/15/rails-6-deprecates-update-attributes/