### PR TITLE
Rails 6.1 - Replace deprecated update_attributes method with update on comment_spec/comment

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -53,7 +53,7 @@ class Comment < ApplicationRecord
   end
 
   def soft_destroy
-    update_attributes is_deleted: true, body: 'This comment has been deleted'
+    update is_deleted: true, body: 'This comment has been deleted'
     mentions.destroy_all
     group_mentions.destroy_all
     tags.destroy_all

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -464,14 +464,14 @@ RSpec.describe Comment, type: :model do
 
   describe '#update_tags' do
     let(:comment){ create :comment, body: '#tag1 not#atag #Tag' }
-    before(:each){ comment.update_attributes body: '#TAG1' }
+    before(:each){ comment.update body: '#TAG1' }
 
     it 'should maintain case' do
       expect(comment.reload.tags.first.name).to eql 'tag1'
     end
 
     context 'when removing' do
-      before(:each){ comment.update_attributes body: '#tag1' }
+      before(:each){ comment.update body: '#tag1' }
 
       it 'should destroy removed tags on update' do
         expect(comment.reload.tags.where(name: 'tag').exists?).to be false
@@ -484,7 +484,7 @@ RSpec.describe Comment, type: :model do
 
     context 'when adding' do
       let(:subject2){ create :subject }
-      before(:each){ comment.update_attributes body: '#tag #newtag' }
+      before(:each){ comment.update body: '#tag #newtag' }
 
       it 'should create added tags on update' do
         expect(comment.reload.tags.where(name: 'newtag').exists?).to be true
@@ -540,7 +540,7 @@ RSpec.describe Comment, type: :model do
 
     context 'when preference is disabled' do
       before(:each) do
-        commenting_user.preference_for(:participating_discussions).update_attributes enabled: false
+        commenting_user.preference_for(:participating_discussions).update enabled: false
       end
 
       it 'should not subscribe the user' do
@@ -570,7 +570,7 @@ RSpec.describe Comment, type: :model do
     before(:each) do
       participating_users.each{ |user| user.subscribe_to discussion, :participating_discussions }
       following_user.subscribe_to discussion, :followed_discussions
-      unsubscribed_user.preference_for(:participating_discussions).update_attributes enabled: false
+      unsubscribed_user.preference_for(:participating_discussions).update enabled: false
     end
 
     it 'should create notifications for subscribed users' do

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe CommentPolicy, type: :policy do
 
   context 'with a locked discussion' do
     let(:user){ create :user }
-    before(:each){ record.discussion.update_attributes locked: true }
+    before(:each){ record.discussion.update locked: true }
     it_behaves_like 'a policy permitting', :index, :show, :upvote, :remove_upvote
     it_behaves_like 'a policy forbidding', :create, :update, :destroy, :move
 


### PR DESCRIPTION
Rails 6.1 - Replace deprecated update_attributes method with update on comment_spec/comment

See: https://blog.saeloun.com/2019/04/15/rails-6-deprecates-update-attributes/ 