### PR TITLE
Rails 6.1 - Replace deprecated update_attributes with update in specs (moderation/discussion) and rake task (migrate_disccusion_focuses)

### DIFF
--- a/lib/tasks/migrate_discussion_focuses.rake
+++ b/lib/tasks/migrate_discussion_focuses.rake
@@ -4,7 +4,7 @@ namespace :data do
     Discussion.where('focus_type' => nil).joins(:comments).where('comments.focus_type' => 'Subject').find_each do |discussion|
       first_comment = discussion.comments.order(created_at: :asc).first
       if first_comment.focus
-        discussion.update_attributes focus_id: first_comment.focus_id, focus_type: first_comment.focus_type
+        discussion.update focus_id: first_comment.focus_id, focus_type: first_comment.focus_type
       end
     end
   end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Discussion, type: :model do
 
     it 'should clear sticky' do
       expect{
-        discussion.update_attributes sticky: false
+        discussion.update sticky: false
       }.to change{
         discussion.sticky_position
       }.to nil
@@ -207,7 +207,7 @@ RSpec.describe Discussion, type: :model do
 
     before(:each) do
       users.each{ |user| user.subscribe_to board, :started_discussions }
-      unsubscribed_user.preference_for(:started_discussions).update_attributes enabled: false
+      unsubscribed_user.preference_for(:started_discussions).update enabled: false
     end
 
     it 'should create notifications for subscribed users' do

--- a/spec/models/moderation_spec.rb
+++ b/spec/models/moderation_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Moderation, type: :model do
   describe '#notify_subscribers' do
     before(:each) do
       admins.each do |admin|
-        admin.preference_for(:moderation_reports).update_attributes enabled: false
+        admin.preference_for(:moderation_reports).update enabled: false
       end
     end
     include_context 'moderation subscriptions'
@@ -156,7 +156,7 @@ RSpec.describe Moderation, type: :model do
     context 'when the preference is disabled' do
       before(:each) do
         admins.each do |admin|
-          admin.preference_for(:moderation_reports).update_attributes enabled: false
+          admin.preference_for(:moderation_reports).update enabled: false
         end
       end
 


### PR DESCRIPTION
Rails 6.1 - Replace deprecated update_attributes with update in specs (moderation/discussion) and rake task (migrate_disccusion_focuses)

See: https://blog.saeloun.com/2019/04/15/rails-6-deprecates-update-attributes/