### PR TITLE
Rails 6.1 Replace deprecated update_attributes to update in data_export_worker

### DIFF
--- a/app/workers/concerns/data_export_worker.rb
+++ b/app/workers/concerns/data_export_worker.rb
@@ -32,7 +32,7 @@ module DataExportWorker
     uploader.upload
     url = uploader.url
     data_request.notify_user message: "Your data export of #{ name } is ready", url: url
-    data_request.update_attributes url: url
+    data_request.update url: url
     ::File.unlink gzip_file
   end
 


### PR DESCRIPTION
Rails 6.1 Replace deprecated update_attributes to update in data_export_worker

See: https://blog.saeloun.com/2019/04/15/rails-6-deprecates-update-attributes/