### PR TITLE
Rails 6.1 - Update specs that check mime type of response header from `content_type` to `media_type`

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ApplicationController, type: :controller do
       before(:each){ get :root, format: :json }
 
       it 'should render json' do
-        expect(response.content_type).to eql 'application/json'
+        expect(response.media_type).to eql 'application/json'
       end
 
       it 'should list resources' do
@@ -21,7 +21,7 @@ RSpec.describe ApplicationController, type: :controller do
       before(:each){ get :root, format: :json_api }
 
       it 'should render json' do
-        expect(response.content_type).to eql 'application/json'
+        expect(response.media_type).to eql 'application/json'
       end
 
       it 'should list resources' do
@@ -36,7 +36,7 @@ RSpec.describe ApplicationController, type: :controller do
       end
 
       it 'should render html' do
-        expect(response.content_type).to eql 'text/html'
+        expect(response.media_type).to eql 'text/html'
       end
 
       it 'should redirect' do

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe CommentsController, type: :controller do
         end
 
         it 'should be json' do
-          expect(response.content_type).to eql 'application/json'
+          expect(response.media_type).to eql 'application/json'
         end
 
         it 'should be an object' do

--- a/spec/support/shared_examples_for_controller_actions.rb
+++ b/spec/support/shared_examples_for_controller_actions.rb
@@ -19,7 +19,7 @@ RSpec.shared_examples_for 'a controller action' do
 
     it 'should be json' do
       # starting from Rails 5+, if responding with 204, content-type of response is set by Rails as nil
-      expect(response.content_type).to eql 'application/json' unless response.status == 204
+      expect(response.media_type).to eql 'application/json' unless response.status == 204
     end
 
     it 'should be an object' do

--- a/spec/support/shared_examples_for_controller_creating.rb
+++ b/spec/support/shared_examples_for_controller_creating.rb
@@ -45,7 +45,7 @@ RSpec.shared_examples_for 'a controller creating' do
       end
 
       it 'should be json' do
-        expect(response.content_type).to eql 'application/json'
+        expect(response.media_type).to eql 'application/json'
       end
 
       it 'should be an object' do

--- a/spec/support/shared_examples_for_controller_updating.rb
+++ b/spec/support/shared_examples_for_controller_updating.rb
@@ -48,7 +48,7 @@ RSpec.shared_examples_for 'a controller updating' do
       end
 
       it 'should be json' do
-        expect(response.content_type).to eql 'application/json'
+        expect(response.media_type).to eql 'application/json'
       end
 
       it 'should be an object' do


### PR DESCRIPTION
Rails 6.1 - Update specs that check mime type of response header from `content_type` to `media_type`

Deprecation Warning: 
`
DEPRECATION WARNING: Rails 6.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. (called from block (3 levels) in <top (required)> at /rails_app/spec/support/shared_examples_for_controller_actions.rb:22)
`

See: [How ActionDispatch::Response#content_type Changed Between Rails 5.2 to 6.1 - FastRuby.io | Rails Upgrade Service](https://www.fastruby.io/blog/how-actiondispatch-response-content-type-changed-rails-5.html)