### PR TITLE
Rails 6.1 - Deprecation Warning: Dangerous Query method deprecation on search.rb

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -13,7 +13,7 @@ class Search < ApplicationRecord
   scope :with_content, ->(terms) {
     query = _parse_query terms
     where('content @@ to_tsquery(?)', query)
-      .order("ts_rank(content, #{ connection.quote query }) desc")
+      .order(Arel.sql("ts_rank(content, #{ connection.quote query }) desc"))
   }
 
   def self.serialize_search


### PR DESCRIPTION
Rails 6.1 - Deprecation Warning: Dangerous Query method deprecation on search.rb

Update search.rb , wrapping order query with Arel.sql 

See: https://www.fastruby.io/blog/rails/security/dangerous-query-method-deprecation.html