### PR TITLE
Rails 6.1 - specify reference to alias table on query within message_policy

### DIFF
--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -34,9 +34,21 @@ class MessagePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.joins(:conversation, :user_conversations).where({
+      # TODO: REMOVE VERSION CHECK ONCE ON RAILS 6.1
+      # Rails 6.1 introduces a feature that allows .where
+      # to access alias tables.
+      # See: https://blog.saeloun.com/2021/01/25/rails-6-allow-where-clause-reference-association-by-alias-name/
+      # This change is not backwards compatible with Rails 6.0
+
+      if Rails.version.starts_with?('6.0')
+        scope.joins(:conversation, :user_conversations).where({
+        user_conversations: { user_id: user.id }
+        })
+      else
+        scope.joins(:conversation, :user_conversations).where({
         user_conversations_messages: { user_id: user.id }
-      })
+        })
+      end
     end
   end
 end

--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -35,7 +35,7 @@ class MessagePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       scope.joins(:conversation, :user_conversations).where({
-        user_conversations: { user_id: user.id }
+        user_conversations_messages: { user_id: user.id }
       })
     end
   end


### PR DESCRIPTION
Rails 6.1 - specify reference to alias table on query within message_policy

Rails 6.1 introduces a feature for `.where` to reference associations via joined table alias names. This causes our multiple inner join query on messages to return a StatementInvalid Error in 6.1 unless we specify the alias table.

Unfortunately, this feature is not backwards compatible with Rails 6.0 so we add a version check . 
TODO: remove version check once officially on Rails 6.1+ 
See: https://blog.saeloun.com/2021/01/25/rails-6-allow-where-clause-reference-association-by-alias-name/