### PR TITLE
Upgrade aws-sdk from v2 to v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ else
   gem 'rails', '6.1.7.10'
 end
 
-gem 'aws-sdk', '~> 2.3.7'
+gem 'aws-sdk-kinesis', '~> 1'
+gem 'aws-sdk-s3', '~> 1'
 # lock concurrent-ruby to 1.3.4 since 1.3.5 breaks active support
 # with a NameError  uninitialized constant
 # ActiveSupport::LoggerThreadSafeLevel::Logger on application.rb
@@ -33,7 +34,7 @@ gem 'sidekiq', '< 6'
 gem 'sidekiq-congestion', '~> 0.1.0'
 gem 'sidekiq-cron'
 gem 'spring', group: :development
-gem 'zoo_stream', '~> 1.0'
+gem 'zoo_stream', '~> 1.1'
 
 group :test, :development do
   gem 'benchmark-ips'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,12 +83,26 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    aws-sdk (2.3.23)
-      aws-sdk-resources (= 2.3.23)
-    aws-sdk-core (2.3.23)
-      jmespath (~> 1.0)
-    aws-sdk-resources (2.3.23)
-      aws-sdk-core (= 2.3.23)
+    aws-eventstream (1.3.1)
+    aws-partitions (1.1055.0)
+    aws-sdk-core (3.219.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kinesis (1.74.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-kms (1.99.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.182.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.11.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     benchmark-ips (2.14.0)
     bigdecimal (3.1.9)
@@ -105,7 +119,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.4.1)
-    diff-lcs (1.5.1)
+    diff-lcs (1.6.0)
     docile (1.4.1)
     domain_name (0.6.20240107)
     erubi (1.13.1)
@@ -189,7 +203,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.5)
+    logger (1.6.6)
     logstash-event (1.2.02)
     logstasher (0.9.0)
       activerecord (>= 3.0)
@@ -210,21 +224,21 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0107)
+    mime-types-data (3.2025.0220)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
     mock_redis (0.41.0)
     multipart-post (2.4.1)
     nenv (0.3.0)
-    net-imap (0.4.18)
+    net-imap (0.4.19)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
     netrc (0.11.0)
     newrelic_rpm (9.17.0)
@@ -247,7 +261,7 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.10)
+    rack (2.2.11)
     rack-cors (1.0.6)
       rack (>= 1.6.0)
     rack-protection (3.2.0)
@@ -295,12 +309,12 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.4.0)
+    rexml (3.4.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.2)
+    rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -359,7 +373,7 @@ GEM
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    webmock (3.24.0)
+    webmock (3.25.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -368,14 +382,15 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.6.18)
-    zoo_stream (1.0.1)
-      aws-sdk
+    zoo_stream (1.1.0)
+      aws-sdk-kinesis (~> 1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk (~> 2.3.7)
+  aws-sdk-kinesis (~> 1)
+  aws-sdk-s3 (~> 1)
   benchmark-ips
   concurrent-ruby (= 1.3.4)
   factory_bot_rails
@@ -409,7 +424,7 @@ DEPENDENCIES
   ten_years_rails
   timecop
   webmock (~> 3.4)
-  zoo_stream (~> 1.0)
+  zoo_stream (~> 1.1)
 
 BUNDLED WITH
    2.4.22

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -83,12 +83,26 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    aws-sdk (2.3.23)
-      aws-sdk-resources (= 2.3.23)
-    aws-sdk-core (2.3.23)
-      jmespath (~> 1.0)
-    aws-sdk-resources (2.3.23)
-      aws-sdk-core (= 2.3.23)
+    aws-eventstream (1.3.1)
+    aws-partitions (1.1055.0)
+    aws-sdk-core (3.219.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kinesis (1.74.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-kms (1.99.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.182.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.11.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     benchmark-ips (2.14.0)
     bigdecimal (3.1.9)
@@ -105,7 +119,7 @@ GEM
       rexml
     crass (1.0.6)
     date (3.4.1)
-    diff-lcs (1.5.1)
+    diff-lcs (1.6.0)
     docile (1.4.1)
     domain_name (0.6.20240107)
     erubi (1.13.1)
@@ -169,7 +183,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.8)
       domain_name (~> 0.5)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
     json-schema (2.8.1)
@@ -189,7 +203,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.5)
+    logger (1.6.6)
     logstash-event (1.2.02)
     logstasher (0.9.0)
       activerecord (>= 3.0)
@@ -210,24 +224,24 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0107)
+    mime-types-data (3.2025.0220)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
     mock_redis (0.41.0)
     multipart-post (2.4.1)
     nenv (0.3.0)
-    net-imap (0.4.18)
+    net-imap (0.4.19)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
     netrc (0.11.0)
-    newrelic_rpm (9.16.1)
+    newrelic_rpm (9.17.0)
     nio4r (2.7.4)
     nokogiri (1.15.7)
       mini_portile2 (~> 2.8.2)
@@ -241,13 +255,13 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.1.1)
-    puma (6.5.0)
+    puma (6.6.0)
       nio4r (~> 2.0)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.10)
+    rack (2.2.11)
     rack-cors (1.0.6)
       rack (>= 1.6.0)
     rack-protection (3.2.0)
@@ -295,12 +309,12 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.4.0)
+    rexml (3.4.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.2)
+    rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -359,7 +373,7 @@ GEM
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    webmock (3.24.0)
+    webmock (3.25.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -368,14 +382,15 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.6.18)
-    zoo_stream (1.0.1)
-      aws-sdk
+    zoo_stream (1.1.0)
+      aws-sdk-kinesis (~> 1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk (~> 2.3.7)
+  aws-sdk-kinesis (~> 1)
+  aws-sdk-s3 (~> 1)
   benchmark-ips
   concurrent-ruby (= 1.3.4)
   factory_bot_rails
@@ -409,7 +424,7 @@ DEPENDENCIES
   ten_years_rails
   timecop
   webmock (~> 3.4)
-  zoo_stream (~> 1.0)
+  zoo_stream (~> 1.1)
 
 BUNDLED WITH
    2.4.22

--- a/config/initializers/zoo_stream.rb
+++ b/config/initializers/zoo_stream.rb
@@ -1,5 +1,5 @@
 if Rails.env.staging? || Rails.env.production?
-  require 'aws-sdk'
+  require 'aws-sdk-kinesis'
   require 'zoo_stream'
   Aws.config.update region: 'us-east-1'
   ZooStream.source = ENV["ZOO_STREAM_SOURCE"] || "talk"

--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 class Uploader
   delegate :initialize_s3, to: :class

--- a/spec/lib/uploader_spec.rb
+++ b/spec/lib/uploader_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe Uploader, type: :lib do
   end
 
   describe '#initialize' do
-    it 'should initialize s3' do
-      expect(Uploader).to receive(:initialize_s3).and_return nil
-      subject
+    it 'sets bucket and bucket_path via initialize_s3' do
+      expect(uploader.bucket).to eq('a-bucket')
+      expect(uploader.bucket_path).to eq('a/bucket/path')
     end
 
     its(:local_file){ is_expected.to eql file }


### PR DESCRIPTION
Part of upgrading app to Ruby 3. Aws-sdk v3 runs into issues when upgrading ruby from v2.7 to v3.0.  Mainly: 
Aws-sdk on Ruby 3 will lead to arg error: try to create proc object without a block. This is due to procs accepting a single rest argument and keyword arguments are no longer subject to autosplatting in ruby 3 vs ruby 2.
See: https://www.fastruby.io/blog/ruby/upgrades/upgrade-ruby-from-2.7-to-3.0.html

Since aws-sdk v3 has 100+ dependencies, it is recommended for direct users to only use the service gems that are required by our project. 

See: https://github.com/aws/aws-sdk-ruby/blob/version-3/V3_UPGRADING_GUIDE.md#user-of-aws-sdk-version-2


### **Changes**
- Update aws-sdk from v2 to v3 
     - Update Gemfile (gemfile.lock and gemfile.next.lock) to only require gems we are directly using (s3 and kinesis)
 - Update zoo_stream from v1.0 to v1.1.0 which requires only necessary aws-kinesis

### **To test on staging and prod**

- [ ]  Creation of talk tag exports still working/communicating with aws correctly

- [ ] Sending comments over through kinesis stream to receiving apps (via zoo_stream). Can test this by seeing if eras comments count has increased when a new comment has been created. 