### PR TITLE
aws-sdk upgrade - update expires_in to be in seconds

### DIFF
--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -25,7 +25,7 @@ class Uploader
   end
 
   def url
-    remote_file.presigned_url :get, expires_in: 1.week
+    remote_file.presigned_url :get, expires_in: 1.week.in_seconds
   end
 
   def mime_type


### PR DESCRIPTION
update expires_in to be in seconds within aws's object's `presigned_url` method

See: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Object.html#presigned_url-instance_method