### PR TITLE
Ruby 2.7 to 3. Update method calls on convo and discussion service and shared specs due to separation of positional and keyword args in ruby 3

### DIFF
--- a/app/controllers/concerns/talk_resource.rb
+++ b/app/controllers/concerns/talk_resource.rb
@@ -11,14 +11,14 @@ module TalkResource
   end
 
   def service
-    @service ||= service_class.new({
+    @service ||= service_class.new(
       params: params,
       action: params[:action],
       current_user: current_user,
       model_class: model_class,
       schema_class: schema_class,
       user_ip: current_user_ip
-    })
+    )
   end
 
   def resource_ids

--- a/app/services/conversation_service.rb
+++ b/app/services/conversation_service.rb
@@ -20,12 +20,12 @@ class ConversationService < ApplicationService
   end
 
   def build_message
-    MessageService.new({
+    MessageService.new(
       params: message_params,
       action: :create,
       current_user: current_user,
       user_ip: user_ip
-    }).build
+    ).build
   end
 
   def conversation_params

--- a/app/services/discussion_service.rb
+++ b/app/services/discussion_service.rb
@@ -2,12 +2,12 @@ class DiscussionService < ApplicationService
   def build
     set_user
     @resource = model_class.new(discussion_params).tap do |discussion|
-      new_comment = CommentService.new({
+      new_comment = CommentService.new(
         params: comment_params,
         action: :create,
         current_user: current_user,
         user_ip: user_ip
-      }).build
+      ).build
       discussion.focus = new_comment.focus
       discussion.comments << new_comment
     end

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -85,13 +85,13 @@ RSpec.describe NotificationsController, type: :controller do
       end
 
       it 'should update all notifications without specified ids' do
-        put :read, { format: :json }
+        put :read, params: { format: :json }
         owned_statuses = record.user.notifications.map{ |notification| notification.reload.delivered }
         expect(owned_statuses).to all be true
       end
 
       it 'should not update other users notifications without specified ids' do
-        put :read, { format: :json }
+        put :read, params: { format: :json }
         other_statuses = others.map{ |notification| notification.reload.delivered }
         expect(other_statuses).to all be false
       end

--- a/spec/support/shared_examples_for_data_export_worker.rb
+++ b/spec/support/shared_examples_for_data_export_worker.rb
@@ -106,8 +106,8 @@ RSpec.shared_examples_for 'a data export worker' do
     end
 
     it 'should call #row_from' do
-      expect(subject).to receive(:row_from).with a: 1
-      expect(subject).to receive(:row_from).with b: 2
+      expect(subject).to receive(:row_from).with({ a: 1 })
+      expect(subject).to receive(:row_from).with({ b: 2 })
       subject.each_row{ }
     end
 


### PR DESCRIPTION
Ruby 2.7 to 3. Update method calls on convo and discussion service and shared specs due to separation of positional and keyword args in ruby 3

See: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/