### PR TITLE
Rails 7- Deprecation utilize configs_for method to retrieve configurations hash

### DIFF
--- a/app/models/panoptes_user.rb
+++ b/app/models/panoptes_user.rb
@@ -1,4 +1,4 @@
 class PanoptesUser < ApplicationRecord
   self.table_name = 'users'
-  establish_connection configurations["panoptes_#{ Rails.env }"]
+  establish_connection configurations.configs_for(env_name: "panoptes_#{Rails.env}")[0].configuration_hash
 end


### PR DESCRIPTION
 Rails 7 - update activerecord base configurations reference on panoptes_user.rb to configs_for to return hash

See: https://www.bigbinary.com/blog/rails-6-changed-activerecord-base-configurations-result-to-an-object