### PR TITLE
Update validation of focusable discussions due to callbacks

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -61,9 +61,9 @@ class Discussion < ApplicationRecord
   end
 
   def focus_belongs_to_project
-    return unless focus && project_id.present?
+    return unless focus && board.project_id.present?
 
-    errors.add(:focus_id, 'Subject must belong to project') if focus.project_id != project_id
+    errors.add(:focus_id, 'Subject must belong to project') if focus.project_id != board.project_id
   end
 
   protected

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -154,9 +154,10 @@ RSpec.describe Comment, type: :model do
     end
 
     context 'with a focused discussion' do
-      let(:focus){ create :subject }
-      let(:discussion){ create :discussion, focus: focus }
-      subject{ create :comment, discussion: discussion }
+      let(:focus) { create :subject }
+      let(:project_board) { create :board, section: "project-#{focus.project_id}" }
+      let(:discussion) { create :discussion, focus: focus, board: project_board }
+      subject { create :comment, discussion: discussion }
       its(:focus){ is_expected.to eql focus }
     end
   end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe Discussion, type: :model do
     context 'when focus_id is present' do
       let(:focus) { create :subject }
       it 'returns validation error if focus subject does not belong to project' do
-        with_focus_unrelated_to_project = build :discussion, focus_id: focus.id, focus_type: 'Subject', project_id: focus.project_id + 1
+        project_board = create :board, section: "project-#{focus.project_id + 1}"
+        with_focus_unrelated_to_project = build :discussion, focus_id: focus.id, focus_type: 'Subject', board: project_board
         expect(with_focus_unrelated_to_project).to fail_validation focus_id: 'Subject must belong to project'
       end
 

--- a/spec/services/discussion_service_spec.rb
+++ b/spec/services/discussion_service_spec.rb
@@ -36,12 +36,14 @@ RSpec.describe DiscussionService, type: :service do
 
     context 'with a focused comment' do
       context 'with a related focus to project board' do
-        let(:focus){ create :subject }
+        let(:project_board) { create :board, section: 'project-212' }
+        let(:related_project) { create :project, id: 212}
+        let(:focus) { create :subject, project: related_project }
         let(:create_params) do
           {
             discussions: {
               title: 'works',
-              board_id: board.id,
+              board_id: project_board.id,
               comments: [{
                 body: 'works',
                 focus_id: focus.id,
@@ -51,12 +53,11 @@ RSpec.describe DiscussionService, type: :service do
           }
         end
 
-        before(:each) { service.create }
-        subject { service.resource }
-
         it 'should set focus of discussion and comment' do
-          expect(subject.focus).to eq(focus)
-          expect(subject.comments.first.focus).to eq(focus)
+          service.create
+          created_discussion = service.resource
+          expect(created_discussion.focus).to eq(focus)
+          expect(created_discussion.comments.first.focus).to eq(focus)
         end
       end
 


### PR DESCRIPTION
Follow up to : https://github.com/zooniverse/talk-api/pull/429

The previous PR did not accomodate typical PFE flow and callbacks. 

Project_id is based on a discussion's board's section 
See:
https://github.com/zooniverse/talk-api/blob/f34343d40e5a9f41c8b05d232ee274436b621638/app/models/discussion.rb#L26
and https://github.com/zooniverse/talk-api/blob/master/app/models/concerns/sectioned.rb 