### PR TITLE
Ruby 3.1 in Production

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -12,8 +12,7 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/build_and_push_image.yaml@main
     with:
       repo_name: talk-api
-      commit_id: ${{ github.sha }}-next
-      file: Dockerfile.rails-next
+      commit_id: ${{ github.sha }}
       latest: true
 
   db_migration_staging:
@@ -23,7 +22,7 @@ jobs:
     with:
       app_name: talk-api
       environment: staging
-      commit_id: ${{ github.sha }}-next
+      commit_id: ${{ github.sha }}
     secrets:
       creds: ${{ secrets.AZURE_AKS }}
 
@@ -34,7 +33,7 @@ jobs:
     with:
       app_name: talk-api
       repo_name: talk-api
-      commit_id: ${{ github.sha }}-next
+      commit_id: ${{ github.sha }}
       environment: staging
     secrets:
       creds: ${{ secrets.AZURE_AKS }}

--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -28,13 +28,7 @@ jobs:
           - Gemfile
           - Gemfile.next
         ruby:
-          - 3.0.7
           - 3.1
-        exclude:
-          - gemfile: Gemfile
-            ruby: 3.1
-          - gemfile: Gemfile.next
-            ruby: 3.0.7
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0-slim-buster
+FROM ruby:3.1-slim-buster
 
 WORKDIR /rails_app
 


### PR DESCRIPTION
Ruby 3.1 in Production
- Update Dockerfile to use Ruby 3.1 image 
- Update deploy_staging to not use -next files 
- Update run tests CI to run Ruby 3.1