### PR TITLE
Create and GET votable tags via controller SLTP #2

### DIFF
--- a/app/controllers/votable_tags_controller.rb
+++ b/app/controllers/votable_tags_controller.rb
@@ -2,7 +2,7 @@
 
 class VotableTagsController < ApplicationController
   include TalkResource
-  disallow :destroy
+  disallow :destroy, :update
 
   def create
     service.create

--- a/app/controllers/votable_tags_controller.rb
+++ b/app/controllers/votable_tags_controller.rb
@@ -7,6 +7,6 @@ class VotableTagsController < ApplicationController
   def create
     service.create
     service.resource.create_vote
-    render json: serializer_class.resource({ id: service.resource.id }, nil, current_user: current_user)
+    render json: serializer_class.resource({ id: service.resource.id }, nil, current_user:)
   end
 end

--- a/app/controllers/votable_tags_controlller.rb
+++ b/app/controllers/votable_tags_controlller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class VotableTagsController < ApplicationController
+  include TalkResource
+  disallow :destroy
+
+  def create
+    service.create
+    service.resource.create_vote
+    render json: serializer_class.resource({ id: service.resource.id }, nil, current_user: current_user)
+  end
+end

--- a/app/models/votable_tag.rb
+++ b/app/models/votable_tag.rb
@@ -12,4 +12,11 @@ class VotableTag < ApplicationRecord
   def soft_destroy
     update is_deleted: true
   end
+
+  def create_vote
+    TagVote.create(
+      user_id: created_by_user_id,
+      votable_tag_id: id
+    )
+  end
 end

--- a/app/policies/votable_tag_policy.rb
+++ b/app/policies/votable_tag_policy.rb
@@ -9,6 +9,14 @@ class VotableTagPolicy < ApplicationPolicy
     logged_in? && confirmed?
   end
 
+  def update?
+    false
+  end
+
+  def destroy?
+    false
+  end
+
   class Scope < Scope
     def resolve
       scope.where(is_deleted: false)

--- a/app/policies/votable_tag_policy.rb
+++ b/app/policies/votable_tag_policy.rb
@@ -9,10 +9,6 @@ class VotableTagPolicy < ApplicationPolicy
     logged_in? && confirmed?
   end
 
-  def update?
-    logged_in? && confirmed?
-  end
-
   class Scope < Scope
     def resolve
       scope.where(is_deleted: false)

--- a/app/policies/votable_tag_policy.rb
+++ b/app/policies/votable_tag_policy.rb
@@ -15,8 +15,6 @@ class VotableTagPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope.all if zooniverse_admin?
-
       scope.where(is_deleted: false)
     end
   end

--- a/app/policies/votable_tag_policy.rb
+++ b/app/policies/votable_tag_policy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class VotableTagPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def create?
+    logged_in? && confirmed?
+  end
+
+  def update?
+    logged_in? && confirmed?
+  end
+
+  class Scope < Scope
+    def resolve
+      return scope.all if zooniverse_admin?
+
+      scope.where(is_deleted: false)
+    end
+  end
+end

--- a/app/schemas/votable_tag_schema.rb
+++ b/app/schemas/votable_tag_schema.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class VotableTagSchema
+  include JSON::SchemaBuilder
+  attr_accessor :policy
+
+  root :votable_tags
+
+  def create
+    root do
+      additional_properties false
+      string :name, required: true
+      string :section, required: true
+      id :taggable_id, null: true
+      id :created_by_user_id, required: true
+      entity :taggable_type, null: true do
+        enum %w[Subject]
+      end
+    end
+  end
+end

--- a/app/serializers/votable_tag_serializer.rb
+++ b/app/serializers/votable_tag_serializer.rb
@@ -1,7 +1,7 @@
 class VotableTagSerializer
   include TalkSerializer
   all_attributes
-  can_filter_by :taggable_id, :taggable_type
+  can_filter_by :taggable_id, :taggable_type, :name, :section
   can_sort_by :name, :vote_count, :created_at, :updated_at
   self.default_sort = '-vote_count'
 end

--- a/app/serializers/votable_tag_serializer.rb
+++ b/app/serializers/votable_tag_serializer.rb
@@ -1,0 +1,7 @@
+class VotableTagSerializer
+  include TalkSerializer
+  all_attributes
+  can_filter_by :taggable_id, :taggable_type
+  can_sort_by :name, :vote_count, :created_at, :updated_at
+  self.default_sort = '-vote_count'
+end

--- a/app/services/votable_tag_service.rb
+++ b/app/services/votable_tag_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class VotableTagService < ApplicationService
+  def build
+    set_created_by_user_id
+    super
+  end
+
+  private
+
+  def set_created_by_user_id(&block)
+    unauthorized! unless current_user
+    begin
+      if block_given?
+        instance_eval(&block)
+      else
+        unrooted_params[:created_by_user_id] = current_user.id
+      end
+    rescue StandardError
+      raise TalkService::ParameterError
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
         get :autocomplete
       end
     end
+    resources :votable_tags
   end
 
   root 'application#root'

--- a/spec/controllers/votable_tags_controller_spec.rb
+++ b/spec/controllers/votable_tags_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe VotableTagsController, type: :controller do
+  let(:resource) { VotableTag }
+  it_behaves_like 'a controller'
+  it_behaves_like 'a controller authenticating'
+  it_behaves_like 'a controller rescuing'
+  it_behaves_like 'a controller rendering', :index, :show
+  it_behaves_like 'a controller restricting',
+                  destroy: { status: 405, response: :error },
+                  update: { status: 405, response: :error },
+                  create: { status: 401, response: :error }
+
+  describe '#create' do
+    let(:user) { create :user }
+    let(:votable_tag_params) do
+      {
+        votable_tags: {
+          section: 'project-1',
+          taggable_id: 1,
+          taggable_type: 'Subject',
+          name: 'hello'
+        }
+      }
+    end
+    before(:each) { allow(subject).to receive(:current_user).and_return user }
+
+    it_behaves_like 'a controller creating' do
+      let(:request_params) { votable_tag_params }
+    end
+
+    it 'creates a tag_vote for the created votable_tag' do
+      post :create, params:  votable_tag_params.merge(format: :json)
+      id = response.json['votable_tags'].first['id']
+      tag_votes = TagVote.where(votable_tag_id: id)
+      expect(tag_votes.count).to eql 1
+      tag_vote = tag_votes[0]
+      expect(tag_vote.user_id).to eql(user.id)
+    end
+  end
+end

--- a/spec/models/votable_tag_spec.rb
+++ b/spec/models/votable_tag_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe VotableTag, type: :model do
     end
   end
 
+  describe '#create_vote' do
+    let(:user) { create :user }
+    it 'creates an associated tag_vote for votable_tag' do
+      votable_tag = create :votable_tag, is_deleted: false, created_by_user_id: user.id
+      votable_tag.create_vote
+      tag_votes = TagVote.where(votable_tag_id: votable_tag.id)
+      expect(tag_votes.count).to eql 1
+      tag_vote = tag_votes[0]
+      expect(tag_vote.user_id).to eql(votable_tag.created_by_user_id)
+    end
+  end
+
   describe '#soft_destroy' do
     it 'should set is_deleted to true' do
       votable_tag = create :votable_tag, is_deleted: false

--- a/spec/policies/votable_tag_policy_spec.rb
+++ b/spec/policies/votable_tag_policy_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe VotableTagPolicy, type: :policy do
+  let!(:record) { create :votable_tag }
+  subject { VotableTagPolicy.new user, record }
+  let(:user) {}
+
+  context 'without a user' do
+    it_behaves_like 'a policy permitting', :index, :show
+    it_behaves_like 'a policy forbidding', :create, :update, :destroy
+  end
+
+  context 'with a user' do
+    let(:user) { create :user }
+    it_behaves_like 'a policy permitting', :index, :show, :create
+    it_behaves_like 'a policy forbidding', :update, :destroy
+  end
+
+  context 'with scope' do
+    let!(:deleted_votable_tag) { create :votable_tag, is_deleted: true }
+    subject { VotableTagPolicy::Scope.new(user, VotableTag).resolve.to_a }
+    it { is_expected.to include(record) }
+    it { is_expected.not_to include(deleted_votable_tag) }
+  end
+end

--- a/spec/schemas/votable_tag_schema_spec.rb
+++ b/spec/schemas/votable_tag_schema_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe VotableTagSchema, type: :schema do
+  describe '#create' do
+    let(:schema_method) { :create }
+    its(:type) { is_expected.to eql 'object' }
+    its(:required) { is_expected.to eql ['votable_tags'] }
+
+    with 'properties .votable_tags' do
+      its(:type) { is_expected.to eql 'object' }
+      its(:required) { is_expected.to eql %w[name section created_by_user_id] }
+      its(:additionalProperties) { is_expected.to be false }
+
+      with :properties do
+        its(:name) { is_expected.to eql type: 'string' }
+        its(:section) { is_expected.to eql type: 'string' }
+        its(:created_by_user_id) { is_expected.to eql id_schema }
+        its(:taggable_id) { is_expected.to eql nullable_id_schema }
+        its(:taggable_type) { is_expected.to eql anyOf: [{ 'enum' => %w[Subject] }, { 'type' => 'null' }] }
+      end
+    end
+  end
+end

--- a/spec/serializers/votable_tag_serializer_spec.rb
+++ b/spec/serializers/votable_tag_serializer_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe VotableTagSerializer, type: :serializer do
+  it_behaves_like 'a talk serializer', exposing: :all
+end

--- a/spec/services/votable_tag_service_spec.rb
+++ b/spec/services/votable_tag_service_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe VotableTagService, type: :service do
+  it_behaves_like 'a service', VotableTag do
+    let(:current_user) { create :user }
+    let(:create_params) do
+      {
+        votable_tags: {
+          section: 'project-1',
+          name: 'tags'
+        }
+      }
+    end
+
+    it_behaves_like 'a service creating', VotableTag do
+      it 'should set the created_by_user_id' do
+        expect(service.build.created_by_user_id).to eql current_user.id
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change is part of SLTP effort. 

Changes: 
- We want to be able to create new votable tags (and as soon as a user creates a tag, they are automatically voted into that tag).  We only allow logged in and confirmed users to create votable tags. 
- These changes allow us to GET and POST/Create votable tags. 

Per UX/UI design: votable tags are only deleted when votes go down to 0. And once created, a user cannot update a votable tag. They can remove their vote (i.e. delete the tag) and then create a new tag. 