### PR TITLE
Use GHCR for staging nginx container

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -88,7 +88,7 @@ spec:
               exec:
                 command: ["/bin/bash", "-c", "cp -R /rails_app/public/* /static-assets"]
         - name: talk-staging-nginx
-          image: zooniverse/nginx
+          image: ghcr.io/zooniverse/docker-nginx
           resources:
             requests:
               memory: "30Mi"


### PR DESCRIPTION
Points the sidecar nginx container to GHCR. The docker-nginx repo has been updated and the `latest` tag now is now nginx version 1.29, so this PR also updates the nginx version (from 1.20). 

Only the staging deployment is affected. Once deployed, I should still be able to access /commit_id.txt and be able to validate the config from within the updated container. If successful, I'll update the production deploy here before doing the same on other apps.