### PR TITLE
Use GHCR for production nginx image

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -92,7 +92,7 @@ spec:
               exec:
                 command: ["/bin/bash", "-c", "cp -R /rails_app/public/* /static-assets"]
         - name: talk-production-nginx
-          image: zooniverse/nginx
+          image: ghcr.io/zooniverse/docker-nginx
           resources:
             requests:
               memory: "30Mi"


### PR DESCRIPTION
Staging looks good, so this updates the production deploy to use the updated version 1.29 nginx image from GHCR.

Checks will be the same: I should be able to access /commit_id.txt and be able to validate the config from within the updated container.