### PR TITLE
Update nginx on the staging canary

### DIFF
--- a/kubernetes/deployment-staging-canary.tmpl
+++ b/kubernetes/deployment-staging-canary.tmpl
@@ -54,7 +54,7 @@ spec:
               exec:
                 command: ["/bin/bash", "-c", "cp -R /rails_app/public/* /static-assets"]
         - name: talk-staging-nginx
-          image: zooniverse/nginx
+          image: ghcr.io/zooniverse/docker-nginx
           resources:
             requests:
               memory: "30Mi"


### PR DESCRIPTION
Staging and production are updated. This updates the staging canary to use GHCR (and the newer version of nginx) in the sidecar container.