### PR TITLE
Create Votable Tags Exports

### DIFF
--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -23,6 +23,7 @@ class DataRequest < ApplicationRecord
   def self.kinds
     {
       tags: TagExportWorker,
+      votable_tags: VotableTagExportWorker,
       comments: CommentExportWorker
     }
   end

--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -8,7 +8,7 @@ class DataRequest < ApplicationRecord
   validates :section, presence: true
   validates :kind, presence: true,
     uniqueness: { scope: [:section, :user_id], message: 'has already been created' },
-    inclusion: { in: %w(tags comments), message: 'must be "tags" or "comments"' }
+    inclusion: { in: %w(tags comments votable_tags), message: 'must be "tags" or "comments" or "votable_tags"' }
 
   before_create :set_expiration
   after_commit :spawn_worker, on: :create

--- a/app/workers/votable_tag_export_worker.rb
+++ b/app/workers/votable_tag_export_worker.rb
@@ -24,6 +24,7 @@ class VotableTagExportWorker
 
   def create_view
     view_model.connection.query <<-SQL
+      create or replace view #{ @view_name } as
       select
         votable_tags.id as tag_id,
         votable_tags.name as tag_name,

--- a/app/workers/votable_tag_export_worker.rb
+++ b/app/workers/votable_tag_export_worker.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class VotableTagExportWorker
+  include ::DataExportWorker
+
+  def perform(data_request_id)
+    self.data_request = ::DataRequest.find data_request_id
+    @view_name = "#{data_request.section.gsub(/-/, '_')}_votable_tags"
+    create_view
+    super
+  end
+
+  def find_each(&block)
+    view_model.find_each batch_size:, &block
+  end
+
+  def row_count
+    view_model.count
+  end
+
+  def row_from(row)
+    row.as_json
+  end
+
+  def create_view
+    view_model.connection.query <<-SQL
+      select
+        votable_tags.id as tag_id,
+        votable_tags.name as tag_name,
+        votable_tags.section as tag_section,
+        votable_tags.taggable_id,
+        votable_tags.taggable_type,
+        votable_tags.vote_count as tag_vote_count,
+        votable_tags.is_deleted as tag_deleted,
+        tag_votes.id as vote_id,
+        tag_votes.user_id,
+        users.login as voter_login,
+        votable_tags.created_by_user_id as tag_created_by_user_id,
+        tag_creator.login as tag_creator_login,
+        tag_votes.created_at as vote_created_at,
+        votable_tags.created_at as tag_created_at
+      from tag_votes
+      join votable_tags on tag_votes.votable_tag_id = votable_tags.id
+      join users on tag_votes.user_id = users.id
+      join users as tag_creator on votable_tags.created_by_user_id = tag_creator.id
+      where votable_tags.section = '#{data_request.section}';
+    SQL
+  end
+
+  def view_model
+    return @_view_model if @_view_model
+
+    view_model_name = @view_name
+    @_view_model = Class.new ::ActiveRecord::Base do
+      self.table_name = view_model_name
+      self.primary_key = :vote_id
+    end
+  end
+end

--- a/spec/factories/data_requests.rb
+++ b/spec/factories/data_requests.rb
@@ -8,6 +8,10 @@ FactoryBot.define do
       kind { 'tags' }
     end
 
+    factory :votable_tags_data_request do
+      kind { 'votable_tags' }
+    end
+
     factory :comments_data_request do
       kind { 'comments' }
     end

--- a/spec/models/data_request_spec.rb
+++ b/spec/models/data_request_spec.rb
@@ -64,6 +64,11 @@ RSpec.describe DataRequest, type: :model do
       data_request = create :tags_data_request
       expect(data_request.worker).to eql TagExportWorker
     end
+
+    it 'should find VotableTagExportWorker' do
+      data_request = create :votable_tags_data_request
+      expect(data_request.worker).to eql VotableTagExportWorker
+    end
   end
 
   describe '#set_expiration' do

--- a/spec/models/data_request_spec.rb
+++ b/spec/models/data_request_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe DataRequest, type: :model do
 
   describe '.kinds' do
     subject{ DataRequest.kinds }
-    it{ is_expected.to eql tags: TagExportWorker, comments: CommentExportWorker }
+    it{ is_expected.to eql tags: TagExportWorker, comments: CommentExportWorker, votable_tags: VotableTagExportWorker }
   end
 
   describe '#worker' do

--- a/spec/schemas/data_request_schema_spec.rb
+++ b/spec/schemas/data_request_schema_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DataRequestSchema, type: :schema do
       with :properties do
         its(:user_id){ is_expected.to eql id_schema }
         its(:section){ is_expected.to eql type: 'string' }
-        its(:kind){ is_expected.to eql type: 'string', enum: %w(tags comments) }
+        its(:kind){ is_expected.to eql type: 'string', enum: %w(tags votable_tags comments) }
       end
     end
   end

--- a/spec/workers/votable_tag_export_worker_spec.rb
+++ b/spec/workers/votable_tag_export_worker_spec.rb
@@ -1,0 +1,139 @@
+require 'spec_helper'
+
+RSpec.describe VotableTagExportWorker, type: :worker do
+  describe 'a data export worker' do
+    before(:each) do
+      allow_any_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter).to receive(:query)
+    end
+
+    it_behaves_like 'a data export worker'
+  end
+
+  def format_of(vote, created_by_user)
+    {
+      tag_id: vote.votable_tag.id,
+      tag_name: vote.votable_tag.name,
+      tag_section: vote.votable_tag.section,
+      taggable_id: vote.votable_tag.taggable_id,
+      taggable_type: vote.votable_tag.taggable_type,
+      tag_vote_count: vote.votable_tag.vote_count,
+      tag_deleted: vote.votable_tag.is_deleted,
+      vote_id: vote.id,
+      user_id: vote.user_id,
+      voter_login: vote.user.login,
+      tag_created_by_user_id: vote.votable_tag.created_by_user_id,
+      tag_creator_login: created_by_user.login,
+      vote_created_at: vote.created_at,
+      tag_created_at: vote.votable_tag.created_at
+    }
+  end
+
+  describe '#view_model' do
+    before(:each) do
+      subject.instance_variable_set :@view_name, 'project_1_votable_tags'
+    end
+
+    it 'should memoize the class' do
+      expect(subject.view_model.object_id).to eql subject.view_model.object_id
+    end
+
+    it 'should set the view name' do
+      expect(subject.view_model.table_name).to eql 'project_1_votable_tags'
+    end
+
+    it 'should set the primary key' do
+      expect(subject.view_model.primary_key).to eql 'vote_id'
+    end
+  end
+
+  describe '#create_view' do
+    let(:user) { create :user }
+    let(:data_request) { create :votable_tags_data_request }
+    let!(:votable_tag) { create :votable_tag, section: data_request.section, created_by_user_id: user.id }
+    let!(:tag_vote) { create :tag_vote, votable_tag_id: votable_tag.id }
+    let(:data) { subject.view_model.all.collect(&:to_json) }
+    before(:each) do
+      subject.data_request = data_request
+      subject.instance_variable_set :@view_name, 'project_1_votable_tags'
+      subject.create_view
+    end
+
+    it 'generates the correct format' do
+      expect(data).to match_array [
+        format_of(tag_vote, user).to_json
+      ]
+    end
+  end
+
+  describe '#row_from' do
+    it 'should call as_json' do
+      row = double as_json: 'works'
+      expect(subject.row_from(row)).to eql 'works'
+    end
+  end
+
+  describe '#find_each' do
+    let(:user) { create :user }
+    let(:data_request) { create :votable_tags_data_request }
+    let!(:votable_tag) { create :votable_tag, section: data_request.section, created_by_user_id: user.id }
+    let!(:tag_vote) { create :tag_vote, votable_tag_id: votable_tag.id }
+
+    before(:each) do
+      subject.data_request = data_request
+      subject.instance_variable_set :@view_name, "#{data_request.section.gsub('-', '_')}_votable_tags"
+      subject.create_view
+    end
+
+    it 'should scope to the view model' do
+      expect(subject).to receive(:view_model).at_least(:once).and_call_original
+      subject.find_each {}
+    end
+
+    it 'should iterate the view model' do
+      expect(subject.view_model).to receive(:find_each).and_call_original
+
+      row = subject.view_model.new format_of(tag_vote, user)
+      expect do |block|
+        subject.find_each(&block)
+      end.to yield_successive_args row
+    end
+
+    it 'should use the batch size' do
+      expect(subject).to receive(:batch_size).and_return 123
+      enumerator = double find_each: nil
+      expect(subject).to receive(:view_model).and_return enumerator
+      expect(enumerator).to receive(:find_each).with batch_size: 123
+      subject.find_each {}
+    end
+  end
+
+  describe '#perform' do
+    let(:data_request){ create :comments_data_request }
+    before(:each) do
+      allow(subject).to receive :process_data
+    end
+
+    it 'should set the data request' do
+      subject.perform data_request.id
+      expect(subject.data_request).to eql data_request
+    end
+
+    it 'should set the view name' do
+      subject.perform data_request.id
+      view_name = subject.instance_variable_get :@view_name
+      expect(view_name).to eql 'project_1_votable_tags'
+    end
+
+    it 'should create the view' do
+      expect(subject).to receive :create_view
+      subject.perform data_request.id
+    end
+  end
+
+  describe '#row_count' do
+    it 'should count section votable_tags' do
+      expect(subject).to receive(:view_model).and_return double count: 5
+      expect(subject.row_count).to eql 5
+    end
+  end
+end

--- a/spec/workers/votable_tag_export_worker_spec.rb
+++ b/spec/workers/votable_tag_export_worker_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe VotableTagExportWorker, type: :worker do
   end
 
   describe '#perform' do
-    let(:data_request){ create :comments_data_request }
+    let!(:data_request) { create :votable_tags_data_request }
     before(:each) do
       allow(subject).to receive :process_data
     end


### PR DESCRIPTION
Create Votable Tags Exports

Based off Comment Exports, creation of a materialized view with info on votes/votable tags

Example format of votable tags json

```
[{
 "tag_id":36,
"tag_name":"hello",
"tag_section":"project-1936",
"taggable_id":15,
"taggable_type":"Subject",
"tag_vote_count":1,
"tag_deleted":false,
"vote_id":49,
"user_id":2,
"voter_login":"tuc04",
"tag_created_by_user_id":1,
"tag_creator_login":"mechellun",
"vote_created_at":"2025-07-30T16:21:24.796Z",
"tag_created_at":"2025-07-30T16:20:33.589Z"
}]

```