### PR TITLE
Use separate endpoint for staging nginx health check

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -21,6 +21,11 @@ data:
         add_header 'Access-Control-Allow-Credentials' 'true';
       }
 
+      location /healthz {
+        add_header Content-Type text/plain;
+        return 200;
+      }
+
       location / {
         proxy_pass http://docker-talk;
       }
@@ -54,6 +59,14 @@ spec:
             limits:
               memory: "600Mi"
               cpu: "500m"
+          startupProbe:
+            httpGet:
+              path: /
+              port: 81
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            failureThreshold: 6
           livenessProbe:
             httpGet:
               path: /
@@ -98,24 +111,20 @@ spec:
               cpu: "500m"
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: 80
               httpHeaders:
                 - name: X-Forwarded-Proto
                   value: https
-                - name: Accept
-                  value: application/json
             initialDelaySeconds: 10
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: 80
               httpHeaders:
                 - name: X-Forwarded-Proto
                   value: https
-                - name: Accept
-                  value: application/json
-            initialDelaySeconds: 20
+            initialDelaySeconds: 5
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
Use a separate endpoint for the sidecar nginx container's health checks, `/healthz`. This mirrors Panoptes and isolates the check against the nginx container from the state of the Rails app. 

This PR implements this in staging only to ensure the config works. It also adds the startupProbe that was added to production to staging for parity. 

See https://github.com/zooniverse/panoptes/pull/3648 for more. 