### PR TITLE
Use separate endpoint for production nginx health check

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -21,6 +21,11 @@ data:
         add_header 'Access-Control-Allow-Credentials' 'true';
       }
 
+      location /healthz {
+        add_header Content-Type text/plain;
+        return 200;
+      }
+
       location / {
         proxy_pass http://docker-talk;
       }
@@ -111,23 +116,19 @@ spec:
               cpu: "500m"
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: 80
               httpHeaders:
                 - name: X-Forwarded-Proto
                   value: https
-                - name: Accept
-                  value: application/json
             initialDelaySeconds: 10
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: 80
               httpHeaders:
                 - name: X-Forwarded-Proto
                   value: https
-                - name: Accept
-                  value: application/json
             initialDelaySeconds: 20
           lifecycle:
             preStop:


### PR DESCRIPTION
Use a separate endpoint for the sidecar nginx container's health checks, /healthz. This mirrors Panoptes and isolates the check against the nginx container from the state of the Rails app.

See https://github.com/zooniverse/talk-api/pull/469 & https://github.com/zooniverse/panoptes/pull/3648.