### PR TITLE
Rate limiting tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /tmp
 /config/*.yml
 !/config/schedule.yml
+/config/keys/*
 /.rvmrc
 /coverage
 **.orig

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require 'rack/attack'
 
 class Rack::Attack
@@ -12,7 +11,23 @@ class Rack::Attack
     return nil unless auth&.start_with?('Bearer ')
 
     token = auth.split(' ').last
-    JWT.decode(token, nil, false)&.first&.dig('data', 'id')
+    begin
+      decode_token(token)&.dig('data', 'id')
+    rescue JWT::DecodeError
+      nil
+    end
+  end
+
+  def self.decode_token(token)
+    JWT.decode(token, jwt_signing_public_key, true, algorithm: 'RS512').first
+  end
+
+  def self.key_file_path
+    Rails.root.join('config', 'keys', "doorkeeper-jwt-#{Rails.env.to_s}.pub").to_s
+  end
+
+  def self.jwt_signing_public_key
+    @jwt_signing_public_key ||= OpenSSL::PKey::RSA.new(File.read(key_file_path))
   end
 
   def self.admin?(req)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -7,34 +7,35 @@ class Rack::Attack
     url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
   )
 
-  def self.throttled_user_id(req)
+  def self.current_user_id(req)
     auth = req.get_header('HTTP_AUTHORIZATION')
     return nil unless auth&.start_with?('Bearer ')
+
     token = auth.split(' ').last
-    user_id = JWT.decode(token, nil, false)&.first&.dig('data', 'id')
+    JWT.decode(token, nil, false)&.first&.dig('data', 'id')
+  end
 
-    # Skip the throttle if unauthenticated OR if the user is an admin
-    return nil if user_id.nil? || Role.exists?(user_id: user_id, name: 'admin')
-
-    user_id
+  def self.admin?(req)
+    user_id = current_user_id(req)
+    user_id.present? && Role.exists?(user_id: user_id, name: 'admin')
   end
 
   # New conversations
   throttle('conversations/create/user', limit: 10, period: 1.hour) do |req|
-    throttled_user_id(req) if req.path == '/conversations' && req.post?
+    current_user_id(req) if req.path == '/conversations' && req.post? && !admin?(req)
   end
 
   throttle('conversations/create/ip', limit: 10, period: 1.hour) do |req|
-    throttled_user_id(req) if req.path == '/conversations' && req.post?
+    req.ip if req.path == '/conversations' && req.post? && !admin?(req)
   end
 
   # Replies to existing conversations
   throttle('messages/create/user', limit: 20, period: 1.hour) do |req|
-    throttled_user_id(req) if req.path == '/messages' && req.post?
+    current_user_id(req) if req.path == '/messages' && req.post? && !admin?(req)
   end
 
   throttle('messages/create/ip', limit: 20, period: 1.hour) do |req|
-    throttled_user_id(req) if req.path == '/messages' && req.post?
+    req.ip if req.path == '/messages' && req.post? && !admin?(req)
   end
 
   # User enumeration
@@ -70,7 +71,7 @@ class Rack::Attack
           throttle: throttle_name,
           ip: request.ip,
           path: request.path,
-          user_id: throttled_user_id(request),
+          user_id: current_user_id(request),
           method: request.request_method,
           period: match_data[:period],
           limit: match_data[:limit],

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -7,28 +7,34 @@ class Rack::Attack
     url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
   )
 
-  def self.hashed_token(req)
-    auth = req.env['HTTP_AUTHORIZATION']
-    return nil if auth.blank?
-    Digest::SHA256.hexdigest(auth)
+  def self.throttled_user_id(req)
+    auth = req.get_header('HTTP_AUTHORIZATION')
+    return nil unless auth&.start_with?('Bearer ')
+    token = auth.split(' ').last
+    user_id = JWT.decode(token, nil, false)&.first&.dig('data', 'id')
+
+    # Skip the throttle if unauthenticated OR if the user is an admin
+    return nil if user_id.nil? || Role.exists?(user_id: user_id, name: 'admin')
+
+    user_id
   end
 
   # New conversations
   throttle('conversations/create/user', limit: 10, period: 1.hour) do |req|
-    hashed_token(req) if req.path == '/conversations' && req.post?
+    throttled_user_id(req) if req.path == '/conversations' && req.post?
   end
 
   throttle('conversations/create/ip', limit: 10, period: 1.hour) do |req|
-    req.ip if req.path == '/conversations' && req.post?
+    throttled_user_id(req) if req.path == '/conversations' && req.post?
   end
 
   # Replies to existing conversations
   throttle('messages/create/user', limit: 20, period: 1.hour) do |req|
-    hashed_token(req) if req.path == '/messages' && req.post?
+    throttled_user_id(req) if req.path == '/messages' && req.post?
   end
 
   throttle('messages/create/ip', limit: 20, period: 1.hour) do |req|
-    req.ip if req.path == '/messages' && req.post?
+    throttled_user_id(req) if req.path == '/messages' && req.post?
   end
 
   # User enumeration
@@ -36,16 +42,41 @@ class Rack::Attack
     req.ip if req.path == '/users' && req.get? && req.params['page'].present?
   end
 
-  # General POST limit
-  throttle('post/ip', limit: 50, period: 5.minutes) do |req|
+  # General POST limit per IP. Track & notify only (no throttle)
+  track('post/ip', limit: 50, period: 5.minutes) do |req|
     req.ip if req.post?
   end
 
+  # Custom response for throttled requests
   self.throttled_responder = lambda do |request|
     match_data = request.env['rack.attack.match_data'] || {}
     retry_after = match_data[:period]
     [ 429, { 'Content-Type' => 'application/json', 'Retry-After' => retry_after.to_s },
       [{ errors: [{ message: "Rate limit exceeded." }] }.to_json]
     ]
+  end
+
+  # Notify Honeybadger when a throttle/track is triggered
+  ActiveSupport::Notifications.subscribe('rack.attack') do |name, start, finish, request_id, payload|
+    request = payload[:request]
+    if [:throttle, :track].include?(request.env['rack.attack.match_type'])
+      throttle_name = request.env['rack.attack.matched']
+      match_data    = request.env['rack.attack.match_data'] || {}
+
+      Honeybadger.notify(
+        "Rack::Attack Rate Limit Triggered: #{throttle_name}",
+        error_class: "RateLimitExceeded",
+        context: {
+          throttle: throttle_name,
+          ip: request.ip,
+          path: request.path,
+          user_id: throttled_user_id(request),
+          method: request.request_method,
+          period: match_data[:period],
+          limit: match_data[:limit],
+          count: match_data[:count]
+        }
+      )
+    end
   end
 end

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -100,6 +100,9 @@ spec:
           volumeMounts:
             - name: static-assets
               mountPath: "/static-assets"
+            - name: jwt-production
+              mountPath: "/rails_app/config/keys"
+              readOnly: true
           lifecycle:
             postStart:
               exec:
@@ -151,6 +154,9 @@ spec:
         - name: talk-nginx-config
           configMap:
             name: talk-nginx-conf-production
+        - name: jwt-production
+          secret:
+            secretName: talk-doorkeeper-jwt-production
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -96,6 +96,9 @@ spec:
           volumeMounts:
             - name: static-assets
               mountPath: "/static-assets"
+            - name: jwt-staging
+              mountPath: "/rails_app/config/keys"
+              readOnly: true
           lifecycle:
             postStart:
               exec:
@@ -146,6 +149,9 @@ spec:
         - name: talk-nginx-config
           configMap:
             name: talk-nginx-conf-staging
+        - name: jwt-staging
+          secret:
+            secretName: talk-doorkeeper-jwt-staging
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -162,9 +162,10 @@ RSpec.describe 'Rate limiting', type: :request do
 
     it 'loads the correct key for the current environment' do
       allow(Rack::Attack).to receive(:jwt_signing_public_key).and_call_original
-      allow(File).to receive(:read).with('/rails_app/config/keys/doorkeeper-jwt-test.pub').and_return(signing_key.public_key)
+      key_file_path = Rails.root.join('config', 'keys', "doorkeeper-jwt-test.pub").to_s
+      allow(File).to receive(:read).with(key_file_path).and_return(signing_key.public_key)
 
-      expect(Rack::Attack).to receive(:key_file_path).and_return(Rails.root.join('config', 'keys', "doorkeeper-jwt-#{Rails.env}.pub").to_s)
+      expect(Rack::Attack).to receive(:key_file_path).and_return(key_file_path)
       Rack::Attack.jwt_signing_public_key
     end
 

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -4,26 +4,47 @@ require 'spec_helper'
 
 RSpec.describe 'Rate limiting', type: :request do
   def jwt_token(user_id)
-    JWT.encode({ sub: user_id }, nil, 'none')
+    JWT.encode({ 'data' => { 'id' => user_id } }, nil, 'none')
   end
 
-  let(:user) { create(:user) }
-  let(:headers) { { 'Authorization' => "Bearer #{jwt_token(user.id)}" } }
+  before(:each) do
+    Rack::Attack.cache.store.clear
+  end
+
+  let(:user) { create(:user, id: 11223344) }
+  let(:auth_headers) { { 'Authorization' => "Bearer #{jwt_token(user.id)}" } }
+
+  # For unauthenticated requests from a specific IP
+  let(:ip) { '1.2.3.4' }
+  let(:ip_headers) { { 'REMOTE_ADDR' => ip } }
 
   describe 'POST /conversations' do
-    it 'allows requests up to the limit' do
-      # test the rate limit, not the controller
-      allow_any_instance_of(ConversationsController).to receive(:create).and_return(nil)
-      10.times do
-        post '/conversations', headers: headers
+    context 'with a standard user' do
+      it 'allows requests up to the limit' do
+        # test the rate limit, not the controller
+        allow_any_instance_of(ConversationsController).to receive(:create).and_return(nil)
+        10.times { post '/conversations', headers: auth_headers }
         expect(response.status).to eq(204)
+      end
+
+      it 'is throttled after the limit' do
+        allow_any_instance_of(ConversationsController).to receive(:create).and_return(nil)
+        55.times { post '/conversations', headers: auth_headers }
+        expect(response.status).to eq(429)
       end
     end
 
-    it 'is throttled after the limit' do
-      allow_any_instance_of(ConversationsController).to receive(:create).and_return(nil)
-      50.times { post '/conversations', headers: headers }
-      expect(response.status).to eq(429)
+    context 'with an user with an admin role' do
+      before do
+        Role.create!(user_id: user.id, name: 'admin', section: 'project-1')
+      end
+
+      it 'does not throttle requests from users with admin roles' do
+        allow_any_instance_of(ConversationsController).to receive(:create).and_return(nil)
+
+        60.times { post '/conversations', headers: auth_headers }
+        expect(response.status).to eq(204)
+      end
     end
   end
 
@@ -31,31 +52,41 @@ RSpec.describe 'Rate limiting', type: :request do
     it 'allows requests up to the limit' do
       allow_any_instance_of(MessagesController).to receive(:create).and_return(nil)
       5.times do
-        post '/messages', headers: headers
+        post '/messages', headers: auth_headers
         expect(response.status).to eq(204)
       end
     end
 
     it 'is throttled after the limit' do
       allow_any_instance_of(MessagesController).to receive(:create).and_return(nil)
-      50.times { post '/messages', headers: headers }
-      post '/messages', headers: headers
+      55.times { post '/messages', headers: auth_headers }
+      expect(response.status).to eq(429)
+    end
+
+    it 'throttles based on token when IP is rotating' do
+      allow_any_instance_of(MessagesController).to receive(:create).and_return(nil)
+      55.times do |i|
+        rotating_headers = auth_headers.merge('REMOTE_ADDR' => "10.0.0.#{i}")
+        post '/messages', headers: rotating_headers
+      end
+
+      post '/messages', headers: auth_headers
       expect(response.status).to eq(429)
     end
   end
 
-  describe 'GET /users' do
+  describe 'GET /users?page=X' do
     it 'allows requests up to the limit' do
       allow_any_instance_of(UsersController).to receive(:index).and_return(nil)
       5.times do
-        get '/users', params: { page: 10 }
+        get '/users', params: { page: 10 }, headers: ip_headers
         expect(response.status).to eq(204)
       end
     end
 
     it 'is throttled after the limit' do
       allow_any_instance_of(UsersController).to receive(:index).and_return(nil)
-      50.times { get '/users', params: { page: 10 } }
+      55.times { get '/users', params: { page: 10 } }
       get '/users', params: { page: 20 }
       expect(response.status).to eq(429)
     end
@@ -65,16 +96,60 @@ RSpec.describe 'Rate limiting', type: :request do
     it 'allows requests up to the limit' do
       allow_any_instance_of(CommentsController).to receive(:create).and_return(nil)
       5.times do
-        post '/comments'
+        post '/comments', headers: ip_headers
         expect(response.status).to eq(204)
       end
     end
+  end
 
-    it 'is throttled after repeated requests' do
-      allow_any_instance_of(CommentsController).to receive(:create).and_return(nil)
-      100.times { post '/comments' }
-      post '/comments'
-      expect(response.status).to eq(429)
+  describe 'Honeybadger notifications' do
+    before do
+      allow(Honeybadger).to receive(:notify)
+    end
+
+    it 'does not notify Honeybadger when under the limit' do
+      post '/conversations', headers: auth_headers
+      expect(Honeybadger).not_to have_received(:notify)
+    end
+
+    it 'sends a notification when the rate limit is hit' do
+      55.times do
+        post '/conversations', headers: auth_headers
+      end
+
+      expect(Honeybadger).to receive(:notify).with(
+        "Rack::Attack Rate Limit Triggered: conversations/create/user",
+        hash_including(
+          error_class: "RateLimitExceeded",
+          context: hash_including(
+            throttle: "conversations/create/user",
+            ip: "127.0.0.1",
+            user_id: user.id,
+            path: "/conversations",
+            method: "POST"
+          )
+        )
+      )
+
+      post '/conversations', headers: auth_headers
+    end
+
+    it 'sends a notification for POST rate limit tracking' do
+      55.times { post '/comments', headers: auth_headers }
+
+      expect(Honeybadger).to receive(:notify).with(
+        "Rack::Attack Rate Limit Triggered: post/ip",
+        hash_including(
+          error_class: "RateLimitExceeded",
+          context: hash_including(
+            throttle: "post/ip",
+            ip: "127.0.0.1",
+            user_id: user.id
+          )
+        )
+      )
+
+      post '/comments', headers: auth_headers
     end
   end
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -3,12 +3,14 @@
 require 'spec_helper'
 
 RSpec.describe 'Rate limiting', type: :request do
+  let(:signing_key) { OpenSSL::PKey::RSA.generate(2048) }
   def jwt_token(user_id)
-    JWT.encode({ 'data' => { 'id' => user_id } }, nil, 'none')
+    JWT.encode({ 'data' => { 'id' => user_id } }, signing_key, 'RS512')
   end
 
   before(:each) do
     Rack::Attack.cache.store.clear
+    allow(Rack::Attack).to receive(:jwt_signing_public_key).and_return(signing_key.public_key)
   end
 
   let(:user) { create(:user, id: 11223344) }
@@ -150,6 +152,53 @@ RSpec.describe 'Rate limiting', type: :request do
       )
 
       post '/comments', headers: auth_headers
+    end
+  end
+
+  describe 'JWT token verification' do
+    before do
+      allow_any_instance_of(ConversationsController).to receive(:create).and_return(nil)
+    end
+
+    it 'loads the correct key for the current environment' do
+      allow(Rack::Attack).to receive(:jwt_signing_public_key).and_call_original
+      allow(File).to receive(:read).with('/rails_app/config/keys/doorkeeper-jwt-test.pub').and_return(signing_key.public_key)
+
+      expect(Rack::Attack).to receive(:key_file_path).and_return(Rails.root.join('config', 'keys', "doorkeeper-jwt-#{Rails.env}.pub").to_s)
+      Rack::Attack.jwt_signing_public_key
+    end
+
+    it 'throttles based on user ID from a valid signed token' do
+      20.times do |i|
+        post '/conversations', headers: auth_headers.merge('REMOTE_ADDR' => "10.0.0.#{i}")
+      end
+
+      expect(response.status).to eq(429)
+    end
+
+    # Somebody else's key, invalid for our public key
+    let(:spooky_signing_key) { OpenSSL::PKey::RSA.generate(2048) }
+
+    it 'does not use the user ID from a token with an invalid signature' do
+      invalid_token = JWT.encode( { 'data' => { 'id' => user.id } }, spooky_signing_key, 'RS512')
+
+      # Rotate IP to test only user throttling
+      20.times do |i|
+        post '/conversations', headers: { 'Authorization' => "Bearer #{invalid_token}", 'REMOTE_ADDR' => "10.0.0.#{i}" }
+      end
+
+      # Req still allowed, so user ID from invalid token wasn't used for throttling
+      expect(response.status).to eq(204)
+    end
+
+    it 'rejects unsigned tokens' do
+      unsigned_token = JWT.encode( { 'data' => { 'id' => user.id } }, nil, 'none')
+
+      20.times do |i|
+        post '/conversations', headers: { 'Authorization' => "Bearer #{unsigned_token}", 'REMOTE_ADDR' => "10.0.0.#{i}" }
+      end
+
+      expect(response.status).to eq(204)
     end
   end
 end


### PR DESCRIPTION
* Skip POST throttles for users with an admin Role
* Use id from decoded token as key
* Send notification to Honeybadger when Rack::Attack is triggered
* Change general per-IP POST limit to a track: HB will get notified but no throttling

post review:
* Verify JWT via public key to prevent token forgery
* Admins skip throttling